### PR TITLE
issue-resolver: require resolution comment on the issue

### DIFF
--- a/.github/agents/issue-resolver.agent.md
+++ b/.github/agents/issue-resolver.agent.md
@@ -23,7 +23,14 @@ You are **Issue Resolver** — a focused worker that takes one issue and ships i
 9. **On failure:** diagnose, push fix commits, re-watch. Do not retry the same approach blindly.
 10. **Merge.** Once required checks are green and review threads resolved: `gh pr merge <PR> --squash --delete-branch --admin`.
 11. **Sync.** `git checkout main && git pull`.
-12. **Report.** Issue link, PR link, commit SHAs, and a one-line status.
+12. **Comment on the issue.** Post a resolution comment via `gh issue comment <N> --body-file <tmp>` summarizing:
+    - PR link and merge commit SHA
+    - Each acceptance criterion with how it was satisfied (one bullet each)
+    - Any deviations from the issue's stated tasks and why
+    - Any follow-up notes worth recording (e.g. lychee placeholder gotchas)
+    Use the pwsh body-file pattern (`@'...'@ | Set-Content $tmp -Encoding UTF8`) — never inline `--body` with backticks.
+    Post the comment even when `Closes #N` already auto-closed the issue; the comment is the durable record.
+13. **Report.** Issue link, PR link, commit SHAs, and a one-line status.
 
 ## Constraints
 


### PR DESCRIPTION
Update the `issue-resolver` agent to add a step 12 requiring a resolution comment on the issue after merge, with explicit guidance to use the pwsh body-file pattern and to comment even when `Closes #N` already auto-closed the issue.

Why: PR #19 merged and auto-closed #18, but no durable record of *what was done* was attached to the issue. Future audits should be able to read the issue and see the resolution without chasing PR history.
