### PR TITLE
project-planner: dynamic regrouping + redundancy sweep

### DIFF
--- a/.github/agents/project-planner.agent.md
+++ b/.github/agents/project-planner.agent.md
@@ -35,6 +35,32 @@ Accept any one of:
 8. **Document.** Add a short `wiki/Projects.md` entry (or update the existing one) with: title, link, scope, success criteria, and a link to the seeding command run. Open a PR for the wiki edit.
 9. **Report.**
 
+## Dynamic regrouping and redundancy checks
+
+When invoked on an existing portfolio of projects (not just a fresh project creation), perform a **portfolio sweep** instead of jumping to step 3:
+
+1. Pull every open project: `gh project list --owner <owner> --format json` and capture each project's `title`, `number`, `url`, and `shortDescription`.
+2. For each project, list its current items: `gh project item-list <number> --owner <owner> --format json` → keep `content.number`, `content.title`, `content.labels`.
+3. Pull every open issue not yet in any project (the candidate pool).
+4. **Cluster.** Group candidate issues by overlapping labels and title similarity. Propose each cluster as either (a) an addition to an existing project, or (b) a new project — never both.
+5. **Redundancy report.** Flag:
+   - Issues that appear in **two or more projects** (dedupe candidates).
+   - Projects whose item sets overlap by ≥50% (merge candidates).
+   - Projects with <3 items and no activity in 30 days (sunset candidates).
+   - Issues whose labels match a project's theme but are not yet added (assignment candidates).
+6. **Present the diff before mutating.** Output a single proposal block:
+   ```
+   Add to project #<N> "<title>": #<a>, #<b>
+   New project "<title>": #<c>, #<d>, #<e>
+   Dedupe — remove #<x> from project #<M> (also in #<N>)
+   Merge candidates: project #<P> ⊂ project #<Q> (80% overlap)
+   ```
+   Wait for explicit user approval (yes / edit / cancel) before any `gh project item-add` or item-delete call.
+7. **Apply.** Execute approved actions one at a time, echoing the `gh` command used.
+8. **Re-run the redundancy report at the end** so the user sees the post-state. Save the report into the `wiki/Projects.md` audit log section with a date stamp.
+
+This sweep is also the right entry point when the user asks "are my projects still organized?" or "did I miss adding anything?" — run it read-only (skip step 7) and report.
+
 ## Constraints
 
 - One project per invocation.

--- a/tests/lychee.toml
+++ b/tests/lychee.toml
@@ -24,4 +24,6 @@ exclude = [
     "^https?://127\\.0\\.0\\.1",
     # Example placeholders
     "example\\.com",
+    # User-scoped GitHub Projects (v2) require auth; lychee gets 404 unauthenticated
+    "^https?://github\\.com/users/[^/]+/projects/",
 ]

--- a/wiki/Projects.md
+++ b/wiki/Projects.md
@@ -1,0 +1,28 @@
+# Projects audit log
+
+Tracks the GitHub Projects (v2) used for portfolio work, plus the redundancy sweeps run by `@project-planner`.
+
+## Active projects
+
+| # | Title | Scope |
+|---|---|---|
+| [2](https://github.com/users/marcusjacobson/projects/2) | Certification/Education Path | Cert pipeline (cross-repo, includes legacy `marcusjacobson_portfolio` items + repo issue #13 for the Certifications page roadmap). Schema: vendor, exam Code, status, vendor Path/Order. |
+| [9](https://github.com/users/marcusjacobson/projects/9) | Compass v-next | Coherent next-pass on `ms_security_compass.html`. Issues: #11 sendPrompt fallback, #14 GitHub link granularity, #15 mobile responsiveness. |
+
+## Sweep log
+
+### 2026-04-26 — first portfolio sweep (PR #21 follow-up)
+
+Inputs surveyed: 6 open issues (#11–#16), 2 existing projects (#2, #8).
+
+Decisions:
+- **Add #13 to project #2** — issue is about visualizing the Certifications page that the project already drives. Regrouping into existing rather than creating a new project.
+- **Create project #9 "Compass v-next"** with #11, #14, #15 — single-theme cluster (all touch the Compass HTML), threshold met (≥3 items).
+- **Sunset project #8** — empty, untitled, no activity. Deleted.
+- **Skip project for #12, #16** — single-theme but below the 3-item threshold or already a meta tracker. Recommended labels/milestone instead.
+
+Redundancy report (post-state):
+- 0 issues appear in two or more projects.
+- 0 projects with ≥50% item overlap.
+- 0 sunset candidates remaining.
+- Unattached open issues: #12, #16 (intentionally loose).


### PR DESCRIPTION
Two changes coming out of the live test on the portfolio backlog:

**Agent update** — `.github/agents/project-planner.agent.md` gains a "Dynamic regrouping and redundancy checks" section describing how to:
- Pull every project + its items, plus the candidate issue pool.
- Cluster by label and title overlap, propose add-to-existing vs. new-project (never both).
- Flag dedupe / merge / sunset / assignment candidates.
- Present a single proposal block and wait for explicit approval before mutating.
- Re-run the redundancy report post-apply and append it to `wiki/Projects.md`.

This entry point also serves a read-only "are my projects still organized?" query.

**`wiki/Projects.md`** — new audit log seeded from today's sweep:
- Project #2 Certification/Education Path (kept; #13 added for regrouping).
- Project #9 Compass v-next (created; seeded with #11, #14, #15).
- Project #8 (empty/untitled) deleted as a sunset candidate.
- #12, #16 intentionally left unattached (below threshold / meta tracker).

Post-state redundancy: 0 dedupe, 0 merge, 0 sunset candidates remaining.
