### PR TITLE
linkedin-sync: scaffold project + fix project-add script

### DIFF
--- a/scripts/gh/add-issue-to-project.ps1
+++ b/scripts/gh/add-issue-to-project.ps1
@@ -2,6 +2,9 @@
 <#
 .SYNOPSIS
     Add a GitHub issue or PR to a Project (v2) by URL.
+.DESCRIPTION
+    Resolves the project number and owner from -ProjectUrl, then calls
+    `gh project item-add <number> --owner <owner> --url <ItemUrl>`.
 #>
 [CmdletBinding()]
 param(
@@ -9,4 +12,12 @@ param(
     [Parameter(Mandatory)][string]$ItemUrl
 )
 $ErrorActionPreference = 'Stop'
-gh project item-add --url $ProjectUrl --content-url $ItemUrl
+
+# Expect URLs of the form https://github.com/(users|orgs)/<owner>/projects/<number>
+if ($ProjectUrl -notmatch 'github\.com/(?:users|orgs)/(?<owner>[^/]+)/projects/(?<number>\d+)') {
+    throw "ProjectUrl is not a Projects v2 URL: $ProjectUrl"
+}
+$owner = $Matches.owner
+$number = [int]$Matches.number
+
+gh project item-add $number --owner $owner --url $ItemUrl

--- a/wiki/Projects.md
+++ b/wiki/Projects.md
@@ -2,7 +2,7 @@
 
 Tracks the GitHub Projects (v2) used for portfolio work, plus the redundancy sweeps run by `@project-planner`.
 
-> Projects v2 are owned at the user level. They surface on the repo's **Projects** tab via `gh project link`. Both projects below are linked to `marcusjacobson/portfolio`.
+> Projects v2 are owned at the user level. They surface on the repo's **Projects** tab via `gh project link`. All projects below are linked to `marcusjacobson/portfolio`.
 
 ## Active projects
 
@@ -10,6 +10,7 @@ Tracks the GitHub Projects (v2) used for portfolio work, plus the redundancy swe
 |---|---|---|
 | [2](https://github.com/users/marcusjacobson/projects/2) | Certification/Education Path | Cert pipeline (cross-repo, includes legacy `marcusjacobson_portfolio` items + repo issue #13 for the Certifications page roadmap). Schema: vendor, exam Code, status, vendor Path/Order. |
 | [9](https://github.com/users/marcusjacobson/projects/9) | Compass v-next | Coherent next-pass on `ms_security_compass.html`. Issues: #11 sendPrompt fallback, #14 GitHub link granularity, #15 mobile responsiveness. |
+| [10](https://github.com/users/marcusjacobson/projects/10) | LinkedIn / Portfolio Sync | Rolling backlog for the `@linkedin-sync` agent build (#24–#30) and any gap-finding issues it generates on later runs. Schema adds **Source** (agent-build / gap-finding / best-practice). |
 
 ## Sweep log
 
@@ -28,3 +29,19 @@ Redundancy report (post-state):
 - 0 projects with ≥50% item overlap.
 - 0 sunset candidates remaining.
 - Unattached open issues: #12, #16 (intentionally loose).
+
+### 2026-04-26 — create LinkedIn / Portfolio Sync project (#10)
+
+Inputs: user request — "create an agent to check my portfolio against my LinkedIn profile and create issues that bring the two in line; re-runnable for new gaps."
+
+Decisions:
+- **New project #10 "LinkedIn / Portfolio Sync"** — passes the 3-item threshold (7 build issues seeded + an open lane for future agent-generated gap issues).
+- **Drafted 7 build issues** (#24 input contract, #25 portfolio claims extractor, #26 gap taxonomy, #27 agent file, #28 best-practice checklist, #29 first live run, #30 docs).
+- **Schema extension** — added single-select `Source` (agent-build / gap-finding / best-practice) so future runs can filter "work to build the agent" vs "work the agent found."
+- **Linked to repo** so it surfaces on the Projects tab.
+- **Fixed** `scripts/gh/add-issue-to-project.ps1` — old `--content-url` flag is gone in gh ≥ 2.x; script now resolves owner+number from the project URL and uses `--url`.
+
+Redundancy report (post-state):
+- 0 issues in two or more projects.
+- 0 project pairs with ≥50% overlap (project #10 is disjoint from #2 and #9).
+- 0 sunset candidates.


### PR DESCRIPTION
Sets up the LinkedIn / Portfolio Sync project (#10) and fixes a script bug discovered while seeding it.

## Project #10 — LinkedIn / Portfolio Sync

Built via `@project-planner`. Now linked to the repo and visible on the Projects tab.

- 7 build issues seeded: #24, #25, #26, #27, #28, #29, #30.
- Custom field: `Source` = `agent-build` | `gap-finding` | `best-practice`.
- Audit log entry added in `wiki/Projects.md`.

## Script fix

`scripts/gh/add-issue-to-project.ps1` was using `gh project item-add --url <project> --content-url <issue>`. The `--content-url` flag was removed in gh CLI 2.x — the current shape is `gh project item-add <number> --owner <owner> --url <issue-url>`. Script now parses owner+number out of the project URL and calls the modern form. Verified against the seeding loop for project #10.
