### PR TITLE
Add sendPrompt() fallback for standalone Pages load

### DIFF
--- a/ms_security_compass.html
+++ b/ms_security_compass.html
@@ -801,6 +801,14 @@ function handleHash(){
 }
 window.addEventListener('hashchange',handleHash);
 window.addEventListener('load',handleHash);
+
+/* Fallback: ensure sendPrompt() exists when the page is loaded standalone
+   (outside the Claude.ai iframe host that normally injects it). */
+if (typeof sendPrompt === 'undefined') {
+  window.sendPrompt = function(text) {
+    window.open('https://claude.ai/new?q=' + encodeURIComponent(text), '_blank');
+  };
+}
 </script>
 
 </body>


### PR DESCRIPTION
Adds the `sendPrompt()` fallback to `ms_security_compass.html` so that real-world scenario buttons work when the page loads standalone on GitHub Pages (outside the Claude.ai iframe that normally injects the function).

The snippet is placed immediately before the last `</script>` and is a no-op when `sendPrompt` is already defined by a host frame.

Closes #11
