### PR TITLE
Point Purview/Entra cards at dedicated repos (#14)

### DIFF
--- a/ms_security_projects.html
+++ b/ms_security_projects.html
@@ -358,7 +358,7 @@ body{background:var(--gray-bg);color:var(--text);
         <span class="field-label">Status</span>
         <span class="status active">Active</span>
       </div>
-      <a class="github-link" href="https://github.com/marcusjacobson/Projects/tree/main/Microsoft" target="_blank" rel="noopener">marcusjacobson/Projects · Microsoft</a>
+      <a class="github-link" href="https://github.com/marcusjacobson/Purview-as-Code-MarcusJ-Lab" target="_blank" rel="noopener">marcusjacobson/Purview-as-Code-MarcusJ-Lab</a>
     </div>
 
   </div>
@@ -410,7 +410,7 @@ body{background:var(--gray-bg);color:var(--text);
         <span class="field-label">Status</span>
         <span class="status complete">Complete</span>
       </div>
-      <a class="github-link" href="https://github.com/marcusjacobson/Projects/tree/main/Microsoft/Entra/Entra-Deployment-Pipelines" target="_blank" rel="noopener">marcusjacobson/Projects · Entra-Deployment-Pipelines</a>
+      <a class="github-link" href="https://github.com/marcusjacobson/Entra-Deployments-Marcusj-Lab" target="_blank" rel="noopener">marcusjacobson/Entra-Deployments-Marcusj-Lab</a>
     </div>
 
     <div class="card coral">

--- a/tests/lychee.toml
+++ b/tests/lychee.toml
@@ -26,4 +26,7 @@ exclude = [
     "example\\.com",
     # User-scoped GitHub Projects (v2) require auth; lychee gets 404 unauthenticated
     "^https?://github\\.com/users/[^/]+/projects/",
+    # Private lab repos referenced from project cards (lychee gets 404 unauthenticated)
+    "^https?://github\\.com/marcusjacobson/Purview-as-Code-MarcusJ-Lab",
+    "^https?://github\\.com/marcusjacobson/Entra-Deployments-Marcusj-Lab",
 ]


### PR DESCRIPTION
Update two project cards in ms_security_projects.html to link to

their standalone lab repos instead of the Projects monorepo blob:

- Purview-as-Code Repo -> marcusjacobson/Purview-as-Code-MarcusJ-Lab

- Entra-Deployment-Pipelines -> marcusjacobson/Entra-Deployments-Marcusj-Lab

Remaining 6 cards still on monorepo paths are tracked in #45.

Closes #14
