### PR TITLE
projects-worker session: Compass v-next (2026-04-26)

### DIFF
--- a/wiki/Projects.md
+++ b/wiki/Projects.md
@@ -25,7 +25,10 @@ Tracks the GitHub Projects (v2) used for portfolio work, plus the redundancy swe
 - **Follow-up issues filed:** #45 "Migrate 6 project cards to dedicated repos" — rollup tracker for the 6 cards on `ms_security_projects.html` that have no dedicated repo (Fabric Purview Governance Sim, Purview Skills Ramp, Purview Discovery Methods Sim, Entra Zero Trust RBAC, SC-300 Masterclass, Sentinel-as-Code). Labeled `content-update area:html priority:p3`, seeded into project #9. Filed before #14 ships so the resolution comment can reference it.
 - **Per-issue transitions:**
   - #14 In review → In progress at 2026-04-26T19:10Z (resumed under user mapping option 1: minimal — update 2 cards, tag 4 repos, defer 6 to #45)
-- **Outcome:** _(populated at session close)_
+  - #14 In progress → Done — PR [#46](https://github.com/marcusjacobson/portfolio/pull/46), merge `bfe2fce`. Side effect: added `tests/lychee.toml` exclude for private lab repos.
+  - #15 Ready → In progress at 2026-04-26T19:30Z
+  - #15 In progress → Done — PR [#47](https://github.com/marcusjacobson/portfolio/pull/47), merge `2d70ca2`. First-time visual baseline lock approved verbatim by user: "update snapshots — lock baselines and ship #15". Scope creep documented in PR: Playwright config ESM→CJS fix and `pages.spec.ts` compass addition were necessary to make AC3 runnable at all.
+- **Outcome:** clean drain. 2/2 worked this session (#14, #15). Combined with prior session: 3/3 of original Compass v-next queue done. Project #9 has 1 open follow-up: #45 (rollup tracker for 6 cards needing dedicated repos, p3, no SLA).
 
 ### 2026-04-26 — projects-worker session: Compass v-next (#9)
 

--- a/wiki/Projects.md
+++ b/wiki/Projects.md
@@ -15,6 +15,17 @@ Tracks the GitHub Projects (v2) used for portfolio work, plus the redundancy swe
 
 ## Sweep log
 
+### 2026-04-26 — projects-worker session: Compass v-next resume (#9)
+
+- **Branch:** `projects-worker/compass-v-next-20260426-resume`
+- **Operator:** projects-worker agent (first session under the audit-log contract from PR #44)
+- **Queue at start:** #14 (In review, returning to flight), #15 (Ready, deferred per user — visual snapshots required)
+- **Status field options:** Ready=`f75ad846`, In Progress=`47fc9ee4`, In review=`84ddce89`, Done=`98236657`
+- **Schema mutations applied:** none (schema stable from earlier session)
+- **Per-issue transitions:**
+  - _(populated as the session runs)_
+- **Outcome:** _(populated at session close)_
+
 ### 2026-04-26 — projects-worker session: Compass v-next (#9)
 
 - **Branch:** `agent/projects-worker-audit-log` (retroactive — pre-dates the audit-log requirement landing in the agent file)

--- a/wiki/Projects.md
+++ b/wiki/Projects.md
@@ -22,8 +22,9 @@ Tracks the GitHub Projects (v2) used for portfolio work, plus the redundancy swe
 - **Queue at start:** #14 (In review, returning to flight), #15 (Ready, deferred per user — visual snapshots required)
 - **Status field options:** Ready=`f75ad846`, In Progress=`47fc9ee4`, In review=`84ddce89`, Done=`98236657`
 - **Schema mutations applied:** none (schema stable from earlier session)
+- **Follow-up issues filed:** #45 "Migrate 6 project cards to dedicated repos" — rollup tracker for the 6 cards on `ms_security_projects.html` that have no dedicated repo (Fabric Purview Governance Sim, Purview Skills Ramp, Purview Discovery Methods Sim, Entra Zero Trust RBAC, SC-300 Masterclass, Sentinel-as-Code). Labeled `content-update area:html priority:p3`, seeded into project #9. Filed before #14 ships so the resolution comment can reference it.
 - **Per-issue transitions:**
-  - _(populated as the session runs)_
+  - #14 In review → In progress at 2026-04-26T19:10Z (resumed under user mapping option 1: minimal — update 2 cards, tag 4 repos, defer 6 to #45)
 - **Outcome:** _(populated at session close)_
 
 ### 2026-04-26 — projects-worker session: Compass v-next (#9)


### PR DESCRIPTION
## Summary

Audit-log + session-close PR for the projects-worker run that drained Compass v-next (#9). This is the durable record required by the agent contract from PR #44.

## Session outcome

- **Project:** Compass v-next (#9)
- **Worked:** 2/2 (this session) — #14 and #15. Combined with the earlier session that did #11, the project's original 3-issue queue is fully drained.
- **Follow-ups filed:** #45 — rollup tracker for the 6 cards on `ms_security_projects.html` that still need dedicated repos. Seeded into project #9 at p3.

## Per-issue summary

| # | Title | PR | Merge |
|---|---|---|---|
| #14 | Improve GitHub project link granularity | [#46](https://github.com/marcusjacobson/portfolio/pull/46) | `bfe2fce` |
| #15 | Compass mobile responsiveness | [#47](https://github.com/marcusjacobson/portfolio/pull/47) | `2d70ca2` |

## Notes worth keeping

- **First-time visual baseline locked** in #47 with explicit user approval. 5 pages × 3 viewports = 15 PNGs in `tests/visual/__snapshots__/`. Future changes that affect rendering will diff against these.
- **Playwright config fix** rode along in #47 (`tests/playwright.config.ts` ESM→CJS) — was necessary to satisfy AC3; documented in the PR.
- **Lychee exclude** rode along in #46 (`tests/lychee.toml`) for private lab repos that 404 anonymously.

## Tested

- [x] All per-issue PRs merged green (lint, lychee, playwright, scan, label, analyze, CodeQL).
- [x] `npm run lint` on this PR passes.
- [x] Audit-log entry conforms to the shape from PR #44.

## Follow-ups

- Decide on a cadence for working #45 (no SLA — repos get created as projects mature).
- Next projects-worker target: any project with items in `Ready`. Cloud Agent Enablement (#11) has 9 issues still in `Todo`/`Backlog` — those need triage into `Ready` first.
