### PR TITLE
Add meta description to index.html for link previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="description" content="Senior Microsoft Cybersecurity Consultant. Portfolio of work across the Microsoft security stack — Purview, Entra, Sentinel, Defender XDR, and Zero Trust.">
+<meta property="og:description" content="Senior Microsoft Cybersecurity Consultant. Portfolio of work across the Microsoft security stack — Purview, Entra, Sentinel, Defender XDR, and Zero Trust.">
+<meta name="twitter:description" content="Senior Microsoft Cybersecurity Consultant. Portfolio of work across the Microsoft security stack — Purview, Entra, Sentinel, Defender XDR, and Zero Trust.">
 <title>Marcus Jacobson — Microsoft Security Portfolio</title>
 <style>
   *{box-sizing:border-box;margin:0;padding:0}


### PR DESCRIPTION
Adds `<meta name="description">` plus `og:description` and `twitter:description` mirrors (same 154-char string) to `index.html` `<head>`.

Closes #50

## Acceptance criteria

- [x] AC1: `<meta name="description">` present in `<head>` (154 chars, within 140–160 range).
- [x] AC2: htmlhint + stylelint pass (`npm run lint`).
- [ ] AC3: LinkedIn Post Inspector confirmation — deferred to post-deploy verification. Tag is in place and will render once Pages publishes from `main`.

## Notes

- Single-line additions only; no structural HTML changes, so visual baselines should be unaffected.
- OG + Twitter mirrors included (trivial, same string) per issue notes for share-card parity.
