### PR TITLE
issue-resolver: tick AC checkboxes in issue body on close

### DIFF
--- a/.github/agents/issue-resolver.agent.md
+++ b/.github/agents/issue-resolver.agent.md
@@ -30,7 +30,12 @@ You are **Issue Resolver** — a focused worker that takes one issue and ships i
     - Any follow-up notes worth recording (e.g. lychee placeholder gotchas)
     Use the pwsh body-file pattern (`@'...'@ | Set-Content $tmp -Encoding UTF8`) — never inline `--body` with backticks.
     Post the comment even when `Closes #N` already auto-closed the issue; the comment is the durable record.
-13. **Report.** Issue link, PR link, commit SHAs, and a one-line status.
+13. **Tick the AC checkboxes in the issue body.** GitHub does not auto-check ACs when a PR closes the issue. Update the issue body so the AC list reflects what shipped:
+    - `gh issue view <N> --json body --jq .body > $tmp` to capture current body.
+    - For each AC that was satisfied: replace `- [ ]` with `- [x]` on that line. Leave any deferred or unverified ACs unchecked (e.g. an AC that requires post-deploy verification stays `- [ ]` and gets called out in the resolution comment instead).
+    - `gh issue edit <N> --body-file $tmp` to write back.
+    - Skip this step if the issue body has no checkbox-style AC list.
+14. **Report.** Issue link, PR link, commit SHAs, and a one-line status.
 
 ## Constraints
 


### PR DESCRIPTION
Adds step 13 to `issue-resolver`: after posting the resolution comment, edit the issue body to flip each satisfied AC from `- [ ]` to `- [x]`. Deferred or unverified ACs (e.g. post-deploy checks) stay unchecked and are called out in the resolution comment instead.\n\nFound via #50 \u2014 the issue closed but the AC checklist still showed all three boxes empty even though two were satisfied at merge time. Backfilled #50 manually as part of this branch's work.\n\n### Tested\n- [x] Manually backfilled #50: `gh issue view 50` now shows AC1+AC2 ticked, AC3 unchecked (deferred).\n- [x] Workflow numbering shifted from 12-step to 13-step; final 'Report' step renumbered to 14.\n\n### Out of scope\nApplying the same pattern to `projects-worker`'s session audit log \u2014 not needed; that log is append-only and never auto-closed.