### PR TITLE
issue-resolver: add p0 conflict-gate before merge

### DIFF
--- a/.github/agents/issue-resolver.agent.md
+++ b/.github/agents/issue-resolver.agent.md
@@ -21,27 +21,33 @@ You are **Issue Resolver** — a focused worker that takes one issue and ships i
 7. **Push + PR.** `git push -u origin <branch>`; `gh pr create --fill`. Body must include `Closes #N`.
 8. **Watch required checks.** `gh pr checks <PR> --watch --interval 15 --required`.
 9. **On failure:** diagnose, push fix commits, re-watch. Do not retry the same approach blindly.
-10. **Merge.** Once required checks are green and review threads resolved: `gh pr merge <PR> --squash --delete-branch --admin`.
-11. **Sync.** `git checkout main && git pull`.
-12. **Comment on the issue.** Post a resolution comment via `gh issue comment <N> --body-file <tmp>` summarizing:
+10. **Conflict gate (blocker).** Before attempting merge, check `gh pr view <PR> --json mergeable,mergeStateStatus --jq '{mergeable,mergeStateStatus}'`. If `mergeable == "CONFLICTING"` or `mergeStateStatus` is `DIRTY` / `BEHIND` requiring rebase that produces conflicts:
+    - **Stop. Do not auto-resolve, do not force-merge, do not `--admin` past the conflict.**
+    - File a `priority:p0` issue titled `Merge conflict on PR #<PR> — blocks #<N>` with body containing: link to the PR, link to the source issue `#N`, the conflicting file list (`gh pr view <PR> --json files --jq '.files[].path'`), the base/head SHAs, and a one-line cause if obvious (e.g. "both branches edited `index.html` `<head>`"). Apply labels matching the conflicted areas (e.g. `area:html`) plus `priority:p0`.
+    - Comment on the original issue `#N` linking the new blocker issue and noting that resolution is paused.
+    - Report and exit. The next invocation must resolve the blocker issue first; only then retry `#N`.
+11. **Merge.** Once required checks are green, no conflicts, and review threads resolved: `gh pr merge <PR> --squash --delete-branch --admin`.
+12. **Sync.** `git checkout main && git pull`.
+13. **Comment on the issue.** Post a resolution comment via `gh issue comment <N> --body-file <tmp>` summarizing:
     - PR link and merge commit SHA
     - Each acceptance criterion with how it was satisfied (one bullet each)
     - Any deviations from the issue's stated tasks and why
     - Any follow-up notes worth recording (e.g. lychee placeholder gotchas)
     Use the pwsh body-file pattern (`@'...'@ | Set-Content $tmp -Encoding UTF8`) — never inline `--body` with backticks.
     Post the comment even when `Closes #N` already auto-closed the issue; the comment is the durable record.
-13. **Tick the AC checkboxes in the issue body.** GitHub does not auto-check ACs when a PR closes the issue. Update the issue body so the AC list reflects what shipped:
+14. **Tick the AC checkboxes in the issue body.** GitHub does not auto-check ACs when a PR closes the issue. Update the issue body so the AC list reflects what shipped:
     - `gh issue view <N> --json body --jq .body > $tmp` to capture current body.
     - For each AC that was satisfied: replace `- [ ]` with `- [x]` on that line. Leave any deferred or unverified ACs unchecked (e.g. an AC that requires post-deploy verification stays `- [ ]` and gets called out in the resolution comment instead).
     - `gh issue edit <N> --body-file $tmp` to write back.
     - Skip this step if the issue body has no checkbox-style AC list.
-14. **Report.** Issue link, PR link, commit SHAs, and a one-line status.
+15. **Report.** Issue link, PR link, commit SHAs, and a one-line status.
 
 ## Constraints
 
 - One issue per invocation. Do not bundle multiple issues into one PR.
 - Never push to `main`.
 - Never bypass required checks (`--no-verify`, deletion of failing tests, etc.).
+- **Never bypass merge conflicts.** Conflicts always escalate to a `priority:p0` blocker issue (step 10); they are never silently rebased or `--admin`-merged through.
 - If the issue lacks a clear acceptance signal, ask the user before guessing.
 - If implementation grows beyond ~200 lines or touches >5 files, stop and ask.
 - For destructive actions (file deletion, label removal, wiki rename), confirm first.


### PR DESCRIPTION
Adds step 10 to `issue-resolver`: a conflict gate that runs before merge.

If `gh pr view --json mergeable,mergeStateStatus` reports `CONFLICTING` / `DIRTY` / `BEHIND`-with-conflicts, the agent now:

1. Stops. No auto-resolve, no force-merge, no `--admin` past the conflict.
2. Files a `priority:p0` blocker issue titled `Merge conflict on PR #<PR> — blocks #<N>` with the conflicting file list, base/head SHAs, and area labels.
3. Comments on the original issue linking the blocker and noting resolution is paused.
4. Reports and exits.

Next invocation must clear the blocker before retrying the original issue.

Also added a constraint line making the no-bypass rule explicit. Step numbering renumbered: merge=11, sync=12, comment=13, tick-ACs=14, report=15.

### Why

Silent rebase or admin-merge through a conflict is the highest-risk path the resolver could take — it''s exactly where intent gets lost (e.g. clobbering a parallel edit). A `p0` issue forces a human decision before the next attempt.

### Tested
- [x] Numbered list renders sequentially (10 through 15).
- [x] No code path changes — agent body only.
