### PR TITLE
Add bug auto-add workflow (#59)

### DIFF
--- a/.github/workflows/bug-autoadd.yml
+++ b/.github/workflows/bug-autoadd.yml
@@ -1,0 +1,27 @@
+name: Bug auto-add to project
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: bug-autoadd-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  add-to-project:
+    name: Add bug-labeled issue to Bug Tracker
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'bug') ||
+      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'bug'))
+    steps:
+      - name: Add issue to project #12
+        uses: actions/add-to-project@244f685bbc3a0a4a9c2c993b75c156b03b350665 # v1.0.2
+        with:
+          project-url: https://github.com/users/marcusjacobson/projects/12
+          github-token: ${{ secrets.BUG_PROJECT_TOKEN }}

--- a/wiki/Projects.md
+++ b/wiki/Projects.md
@@ -12,7 +12,11 @@ Tracks the GitHub Projects (v2) used for portfolio work, plus the redundancy swe
 | [9](https://github.com/users/marcusjacobson/projects/9) | Compass v-next | Coherent next-pass on `ms_security_compass.html`. Issues: #11 sendPrompt fallback, #14 GitHub link granularity, #15 mobile responsiveness. |
 | [10](https://github.com/users/marcusjacobson/projects/10) | LinkedIn / Portfolio Sync | Rolling backlog for the `@linkedin-sync` agent build (#24–#30) and any gap-finding issues it generates on later runs. Schema adds **Source** (agent-build / gap-finding / best-practice). |
 | [11](https://github.com/users/marcusjacobson/projects/11) | Cloud Agent Enablement | One-shot deliverable to enable the GitHub-hosted Copilot cloud agent (Agents tab + `@copilot` assignment): `AGENTS.md`, `copilot-setup-steps.yml`, `agent-task` template, MCP allow-list, smoke test, docs. Issues #32–#40. Schema adds **Source** (config / docs / smoke-test). Complementary to project #10 via Option B manual handoff: LinkedIn-Sync emits gap issues in the `agent-task` template; humans triage and assign `@copilot`. |
-| [12](https://github.com/users/marcusjacobson/projects/12) | Bug Tracker | Rolling backlog for every issue tagged `bug`. Schema adds **Priority** (p0–p3), **Severity** (Critical/Major/Minor/Trivial), **Area** (html/css/docs/wiki/workflow), **Reported** (date). Status: Backlog → Triaged → In progress → In review → Done. Seeded by `@bug-intake`; first item #57 (tagline width). |
+| [12](https://github.com/users/marcusjacobson/projects/12) | Bug Tracker | Rolling backlog for every issue tagged `bug`. Schema adds **Priority** (p0–p3), **Severity** (Critical/Major/Minor/Trivial), **Area** (html/css/docs/wiki/workflow), **Reported** (date). Status: Backlog → Triaged → In progress → In review → Done. Auto-seeded by the `Bug auto-add to project` workflow (`.github/workflows/bug-autoadd.yml`); the `@bug-intake` agent files the issue with the `bug` label and the workflow adds it to project #12. First item: #57 (tagline width). |
+
+## Secrets
+
+- **`BUG_PROJECT_TOKEN`** — fine-grained PAT (or GitHub App installation token) with `Projects: read+write` on user `marcusjacobson`. Used by `.github/workflows/bug-autoadd.yml` to add issues to project #12. The default `GITHUB_TOKEN` cannot write user-scope Projects v2, which is why a separate token is required. Rotate every 12 months or sooner; if expired, the auto-add workflow fails silently from the issue's perspective (the workflow run itself errors). Repository secret name: `BUG_PROJECT_TOKEN`.
 
 ## Sweep log
 


### PR DESCRIPTION
Closes #59. Adds .github/workflows/bug-autoadd.yml to auto-seed any bug-labeled issue into project #12. Documents the BUG_PROJECT_TOKEN secret in wiki/Projects.md. Smoke test deferred until secret is provisioned.