### PR TITLE
Fix actions/add-to-project SHA pin

### DIFF
--- a/.github/workflows/bug-autoadd.yml
+++ b/.github/workflows/bug-autoadd.yml
@@ -21,7 +21,7 @@ jobs:
       (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'bug'))
     steps:
       - name: Add issue to project #12
-        uses: actions/add-to-project@244f685bbc3a0a4a9c2c993b75c156b03b350665 # v1.0.2
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/users/marcusjacobson/projects/12
           github-token: ${{ secrets.BUG_PROJECT_TOKEN }}


### PR DESCRIPTION
Prior commit pinned to a SHA that doesn't exist (typo). Corrects to the real v1.0.2 SHA: 244f685bbc3b7adfa8466e08b698b5577571133e. Smoke test in #61 surfaced the failure.