### PR TITLE
Add readme-summary frontmatter for human-tuned README rows

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -1,6 +1,6 @@
 # Agents
 
-Specialized chat agents (`*.agent.md`) you can summon in Copilot Chat with `@<agent-name>`. Each agent owns a narrow workflow and hands off to others rather than doing everything itself. This file is the human-readable index — keep it in sync with the `description:` frontmatter of each agent file. Use [`/sync-agent-prompt-readmes`](../prompts/sync-agent-prompt-readmes.prompt.md) to regenerate the **Index** table below.
+Specialized chat agents (`*.agent.md`) you can summon in Copilot Chat with `@<agent-name>`. Each agent owns a narrow workflow and hands off to others rather than doing everything itself. This file is the human-readable index — keep it in sync with the `readme-summary:` frontmatter of each agent file (the agent runtime separately consumes `description:`). Use [`/sync-agent-prompt-readmes`](../prompts/sync-agent-prompt-readmes.prompt.md) to regenerate the **Index** table below.
 
 ## Index
 

--- a/.github/agents/bug-intake.agent.md
+++ b/.github/agents/bug-intake.agent.md
@@ -1,5 +1,6 @@
 ---
 description: "Specialized intake for bug reports in this repo via Copilot Chat: classify, repro, draft a bug issue, and route it to a bug-tracking project. Engages only when the user describes broken or regressed behavior. Read-only by default; never mutates GitHub without explicit user approval."
+readme-summary: "Bug-shaped variant of intake: gathers repro steps, environment, and evidence, then routes to a bug-tracking project. Defers back to `@request-intake` if the report isn't actually a bug."
 tools: [read, search, execute, github/*, todo]
 ---
 

--- a/.github/agents/issue-resolver.agent.md
+++ b/.github/agents/issue-resolver.agent.md
@@ -1,5 +1,6 @@
 ---
 description: "Use to resolve a single GitHub issue end-to-end: branch, implement, lint, commit, open PR, watch checks, merge. Requires an explicit issue number."
+readme-summary: "Resolves a single GitHub issue end-to-end: branch, implement, lint, commit, open PR, watch checks, merge. Requires an explicit issue number."
 tools: [read, edit, search, execute, github/*, todo]
 ---
 

--- a/.github/agents/project-planner.agent.md
+++ b/.github/agents/project-planner.agent.md
@@ -1,5 +1,6 @@
 ---
 description: "Use to scope and create a GitHub Project (v2) from a theme, milestone, or cluster of issues. Decides if a new project is warranted, designs fields and views, runs scripts/gh/create-project.ps1, and seeds items via add-issue-to-project.ps1."
+readme-summary: "Scopes and creates a GitHub Project (v2) from a theme or cluster of issues. Designs fields/views and seeds items via `scripts/gh/`."
 tools: [read, edit, search, execute, github/*, todo]
 ---
 

--- a/.github/agents/projects-worker.agent.md
+++ b/.github/agents/projects-worker.agent.md
@@ -1,5 +1,6 @@
 ---
 description: "Use to work an entire GitHub Project (v2): pick the next eligible issue, hand it to the issue-resolver agent, update the project status, and repeat until the project is empty or the user halts."
+readme-summary: "Drains a GitHub Project (v2) by picking the next eligible item and handing each one to `@issue-resolver`, updating Status as it goes."
 tools: [read, edit, search, execute, github/*, todo]
 ---
 

--- a/.github/agents/publish-manager.agent.md
+++ b/.github/agents/publish-manager.agent.md
@@ -1,5 +1,6 @@
 ---
 description: "Use when orchestrating a portfolio publish: validate locally, branch, commit, push, open PR, and watch checks. Coordinates content, lint, and visual checks before staging."
+readme-summary: "Orchestrates a portfolio publish: local validation, branch, commit, push, PR, and check-watching."
 tools: [read, edit, search, execute, todo]
 ---
 

--- a/.github/agents/repo-ops.agent.md
+++ b/.github/agents/repo-ops.agent.md
@@ -1,5 +1,6 @@
 ---
 description: "Use when managing GitHub Issues, Projects, Labels, or Wiki content from chat. Drives the gh CLI scripts in scripts/gh/ and the GitHub MCP server."
+readme-summary: "Generic catch-all for Issues, Projects, Labels, and Wiki ops driven by `gh` CLI and the GitHub MCP server. Use when no other agent fits."
 tools: [read, edit, search, execute, github/*]
 ---
 

--- a/.github/agents/request-intake.agent.md
+++ b/.github/agents/request-intake.agent.md
@@ -1,5 +1,6 @@
 ---
 description: "Use to triage any new request the user makes in this repo via Copilot Chat: classify it, draft a GitHub issue, and propose a project home. Always-on intake — runs on every new feature/bug/chore-shaped request before implementation. Read-only by default; never mutates GitHub without explicit user approval."
+readme-summary: "Front door for any feature/chore/docs ask. Classifies the request, drafts an issue, proposes a project home, and waits for approval before filing."
 tools: [read, search, execute, github/*, todo]
 ---
 

--- a/.github/agents/security-reviewer.agent.md
+++ b/.github/agents/security-reviewer.agent.md
@@ -1,5 +1,6 @@
 ---
 description: "Use when reviewing PR diffs for XSS, secrets, supply-chain risks, unsafe workflow permissions, and CDN trust. Read-only."
+readme-summary: "Reviews a PR diff for XSS, secret leakage, supply-chain risk, unsafe workflow permissions, and CDN trust."
 tools: [read, search, execute]
 ---
 

--- a/.github/prompts/README.md
+++ b/.github/prompts/README.md
@@ -1,6 +1,6 @@
 # Prompts
 
-Slash-command prompts (`*.prompt.md`) you can invoke in Copilot Chat with `/<prompt-name>`. Prompts are single-shot workflows — they run to completion against the current context — whereas [agents](../agents/README.md) are conversational and persist across turns. This file is the human-readable index — keep it in sync with the `description:` frontmatter of each prompt file. Use [`/sync-agent-prompt-readmes`](sync-agent-prompt-readmes.prompt.md) to regenerate the **Index** table below.
+Slash-command prompts (`*.prompt.md`) you can invoke in Copilot Chat with `/<prompt-name>`. Prompts are single-shot workflows — they run to completion against the current context — whereas [agents](../agents/README.md) are conversational and persist across turns. This file is the human-readable index — keep it in sync with the `readme-summary:` frontmatter of each prompt file (the prompt runtime separately consumes `description:`). Use [`/sync-agent-prompt-readmes`](sync-agent-prompt-readmes.prompt.md) to regenerate the **Index** table below.
 
 ## Index
 
@@ -11,7 +11,7 @@ Slash-command prompts (`*.prompt.md`) you can invoke in Copilot Chat with `/<pro
 | [`/groom-backlog`](groom-backlog.prompt.md) | Backlog grooming pass: list open issues, flag duplicates, stale items, and unlabeled work; propose a prioritized batch for the next iteration. | Run `/triage-issue` on each item the groom surfaces. |
 | [`/publish-update`](publish-update.prompt.md) | Guided publish flow: branch, summarize changes, capture screenshots, label the PR, and open it. | Invoke [`@publish-manager`](../agents/publish-manager.agent.md) for end-to-end orchestration, or [`@security-reviewer`](../agents/security-reviewer.agent.md) before merge. |
 | [`/secure-code-review`](secure-code-review.prompt.md) | Secure review of a PR diff: scans for XSS, secret leakage, supply-chain risk, and unsafe inline scripts; integrates CodeQL and gitleaks results. | Pair with [`@security-reviewer`](../agents/security-reviewer.agent.md) for deeper review. |
-| [`/sync-agent-prompt-readmes`](sync-agent-prompt-readmes.prompt.md) | Scans `.github/agents/` and `.github/prompts/` and rewrites the Index tables in both READMEs from the current `description:` frontmatter. | None — runs once and reports a diff. |
+| [`/sync-agent-prompt-readmes`](sync-agent-prompt-readmes.prompt.md) | Scans `.github/agents/` and `.github/prompts/` and rewrites the Index tables in both READMEs from the current `readme-summary:` (or `description:`) frontmatter. | None — runs once and reports a diff. |
 <!-- END: prompts-index -->
 
 ## Prompts vs. agents

--- a/.github/prompts/groom-backlog.prompt.md
+++ b/.github/prompts/groom-backlog.prompt.md
@@ -1,5 +1,6 @@
 ---
 description: "Backlog grooming pass: list open issues, identify duplicates, stale items, and unlabeled work; propose a prioritized batch for the next iteration."
+readme-summary: "Backlog grooming pass: list open issues, flag duplicates, stale items, and unlabeled work; propose a prioritized batch for the next iteration."
 agent: "agent"
 ---
 

--- a/.github/prompts/publish-update.prompt.md
+++ b/.github/prompts/publish-update.prompt.md
@@ -1,5 +1,6 @@
 ---
 description: "Guided publish flow for portfolio updates: branch, summary, screenshot capture, label, and PR creation."
+readme-summary: "Guided publish flow: branch, summarize changes, capture screenshots, label the PR, and open it."
 argument-hint: "Brief description of the update"
 agent: "agent"
 ---

--- a/.github/prompts/secure-code-review.prompt.md
+++ b/.github/prompts/secure-code-review.prompt.md
@@ -1,5 +1,6 @@
 ---
 description: "Secure code review of a PR diff: scans for XSS, secret leakage, supply-chain risk, and unsafe inline scripts; integrates CodeQL and gitleaks results."
+readme-summary: "Secure review of a PR diff: scans for XSS, secret leakage, supply-chain risk, and unsafe inline scripts; integrates CodeQL and gitleaks results."
 argument-hint: "PR number (or 'current branch')"
 agent: "agent"
 ---

--- a/.github/prompts/sync-agent-prompt-readmes.prompt.md
+++ b/.github/prompts/sync-agent-prompt-readmes.prompt.md
@@ -1,12 +1,22 @@
 ---
 description: "Scans .github/agents/ and .github/prompts/ and rewrites the Index tables in both READMEs from current frontmatter. Idempotent. Does not touch hand-authored sections."
+readme-summary: "Scans `.github/agents/` and `.github/prompts/` and rewrites the Index tables in both READMEs from the current `readme-summary:` (or `description:`) frontmatter."
 argument-hint: "(no arguments)"
 agent: "agent"
 ---
 
 # Sync agent and prompt READMEs
 
-Rebuild the **Index** tables inside `.github/agents/README.md` and `.github/prompts/README.md` from the `description:` frontmatter of every `*.agent.md` / `*.prompt.md` file in those folders.
+Rebuild the **Index** tables inside `.github/agents/README.md` and `.github/prompts/README.md` from the frontmatter of every `*.agent.md` / `*.prompt.md` file in those folders.
+
+## Source of truth for the Purpose column
+
+The **Purpose** column is rendered from frontmatter using the following precedence:
+
+1. `readme-summary:` — short, repo-aware human prose tuned for these READMEs. **Use this when it exists** so the rendered table is byte-identical to what a human would hand-write.
+2. `description:` — fallback only. The agent-router selection text is keyword-rich and verbose; rendering it raw produces wordier rows than the curated style.
+
+Why two fields: `description:` is consumed by the agent/prompt router for relevance matching and is tuned for that audience. `readme-summary:` is consumed by this prompt and is tuned for human readers of the README index. They evolve independently.
 
 ## Inputs
 
@@ -18,7 +28,8 @@ None. The prompt operates on whatever is currently checked out.
 - **Idempotent.** Running this prompt twice in a row must produce zero diff.
 - **Bounded edits.** Only the regions delimited by `<!-- BEGIN: agents-index -->` / `<!-- END: agents-index -->` and `<!-- BEGIN: prompts-index -->` / `<!-- END: prompts-index -->` may change. Everything else (How they fit together, Conventions, See also, etc.) is hand-authored and must remain byte-identical.
 - **Read-only on missing markers.** If either marker pair is missing from a README, abort with an error pointing the user at the file. Do not invent the markers.
-- **Skip files without `description:`.** Warn but do not fail.
+- **Prefer `readme-summary:` over `description:`.** Fall back to `description:` only when `readme-summary:` is missing, and warn so a maintainer can add the field.
+- **Skip files without any summary field.** Warn but do not fail.
 
 ## Steps
 
@@ -36,11 +47,11 @@ foreach ($f in '.github/agents/README.md','.github/prompts/README.md') {
 
 For each `.github/agents/*.agent.md`:
 
-1. Parse YAML frontmatter; read `description:`.
-2. Skip the file if `description:` is absent (warn).
+1. Parse YAML frontmatter; read `readme-summary:` if present, otherwise `description:`. If neither is present, skip the file and warn.
+2. If only `description:` was found, emit a warning suggesting the maintainer add a `readme-summary:` field.
 3. Derive **Agent** column: `[`@<name>`](<filename>)` where `<name>` is the basename without `.agent.md`.
-4. Derive **Purpose** column: paraphrase the description into 1–2 sentences. Strip leading "Use to "/"Use when "/"Specialized " noise. Keep imperative voice.
-5. Derive **Mutates repo?** column from explicit signals in the description:
+4. Derive **Purpose** column: use the chosen summary verbatim if it came from `readme-summary:`. If it came from `description:`, paraphrase into 1–2 sentences and strip leading "Use to "/"Use when "/"Specialized " noise.
+5. Derive **Mutates repo?** column from explicit signals in the `description:` field (always read this from `description:`, never from `readme-summary:` — the description is keyword-rich and consistently includes mutation-scope signals; the readme-summary is short prose that often omits them):
    - Contains "read-only" or "Read-only by default" → `Read-only` (or `Read-only until approval` if "until approval" / "without explicit user approval" appears).
    - Contains "creates", "merges", "pushes", "opens PR", "drives the gh CLI" → `Yes`.
    - Project-creating agents → `Yes (project + items)`.
@@ -52,8 +63,8 @@ Preserve the existing row order from the README when a row already exists; appen
 
 For each `.github/prompts/*.prompt.md`:
 
-1. Parse YAML frontmatter; read `description:`.
-2. Skip the file if `description:` is absent (warn).
+1. Parse YAML frontmatter; read `readme-summary:` if present, otherwise `description:`. If neither is present, skip the file and warn.
+2. If only `description:` was found, emit a warning suggesting the maintainer add a `readme-summary:` field.
 3. Derive **Prompt** column: `[`/<name>`](<filename>)` where `<name>` is the basename without `.prompt.md`.
 4. Derive **Purpose** column the same way as for agents.
 5. **Typical follow-up** column is hand-curated — preserve whatever the existing README row says. For new prompts with no prior row, leave it as `_TBD_` and warn the user to fill it in.

--- a/.github/prompts/triage-issue.prompt.md
+++ b/.github/prompts/triage-issue.prompt.md
@@ -1,5 +1,6 @@
 ---
 description: "Triage a single GitHub issue: classify, label, link to project, set priority, and ask any clarifying questions in a comment."
+readme-summary: "Triage one GitHub issue: classify, label, link to a project, set priority, and post any clarifying questions as a comment."
 argument-hint: "Issue number"
 agent: "agent"
 ---


### PR DESCRIPTION
## Summary

Closes #70.

Decouples the README Index Purpose text from the agent/prompt-router
`description:` field by adding a new optional frontmatter field:
`readme-summary:`. The `/sync-agent-prompt-readmes` prompt now prefers
`readme-summary:` for the **Purpose** column, falling back to `description:`
only when missing. The **Mutates repo?** column still derives from
`description:` because that text consistently carries the read-only / mutation
signals.

## Background

PR #69 shipped the sync prompt; PR #68 shipped the hand-polished READMEs.
Smoke-testing the prompt revealed that running it on `main` would replace the
polished prose with longer, router-tuned `description:` text — regressing PR
#68. Two audiences, two fields.

## Changes

- `.github/agents/*.agent.md` (8 files): added `readme-summary:` matching the
  current README rows verbatim.
- `.github/prompts/*.prompt.md` (5 files): same, for prompts.
- `.github/prompts/sync-agent-prompt-readmes.prompt.md`: documents the new
  field and its precedence; clarifies that the `Mutates repo?` column derives
  from `description:` not `readme-summary:`.
- `.github/agents/README.md` and `.github/prompts/README.md`: updated intro
  paragraphs to point readers at `readme-summary:` and note that
  `description:` belongs to the agent/prompt runtime.

## Verification

Re-implemented the prompt's logic in pwsh and ran it against the working tree:

```text
=== Run 1 ===
Agents README:    unchanged
Prompts README:   unchanged
=== Run 2 ===
Agents README:    unchanged
Prompts README:   unchanged
```

Two consecutive runs produce zero diff inside both marker blocks.

## Tested

- [x] All 13 files have parseable `readme-summary:` frontmatter
- [x] Prompt logic prefers `readme-summary:` over `description:`
- [x] `Mutates repo?` column unchanged from PR #68 rows (Read-only,
  Read-only until approval, Yes, Yes (project + items))
- [x] Two consecutive sync runs are no-ops
- [x] Marker blocks are the only mutable region
- [x] No new dependencies
