### PR TITLE
Fix @project-intake: gh project item-create has no --body-file flag

### DIFF
--- a/.github/agents/project-intake.agent.md
+++ b/.github/agents/project-intake.agent.md
@@ -183,14 +183,16 @@ Do not invoke any `gh` mutation. Acceptable approvals:
 
 Run, in order, echoing each command:
 
-1. **Create the DraftIssue on project #13** using the pwsh body-file pattern (single-quoted here-string, never inline backtick-escaped). Capture the returned project item id (`PVTI_…`):
+1. **Create the DraftIssue on project #13.** Note: `gh project item-create` only supports `--body` (no `--body-file`), so write the body to a temp file then load it with `Get-Content -Raw` to preserve newlines. Capture the returned project item id (`PVTI_…`):
    ```pwsh
    $body = @'
    <body content>
    '@
    $tmp = New-TemporaryFile
    $body | Set-Content $tmp -Encoding UTF8
-   $created = gh project item-create 13 --owner marcusjacobson --title "<title>" --body-file $tmp --format json | ConvertFrom-Json
+   $bodyText = Get-Content $tmp -Raw
+   $created = gh project item-create 13 --owner marcusjacobson --title "<title>" --body $bodyText --format json | ConvertFrom-Json
+   Remove-Item $tmp -Force
    $itemId = $created.id   # PVTI_… project item id, used in step 2 below
    ```
 2. **Set project fields** using the field IDs and option IDs captured in step 2's discovery:
@@ -223,6 +225,6 @@ Decide:
 - **`Project` label is reserved for real issues** filed outside this agent (handled by `.github/workflows/project-autoadd.yml`). This agent's path bypasses both the label and the workflow.
 - **Status/Pillar/Tier/Priority use `gh project item-edit` with `--single-select-option-id`**, not `--text`.
 - For `gh project item-edit` calls in step 7, `--id` is the **project item id** (`PVTI_…`) returned by `gh project item-create`. If you ever need to update the draft's body later, that requires the **draft content id** (`DI_…`) which is a different value visible under `content.id` in `gh project item-list` output — do not confuse the two.
-- Always use the pwsh body-file pattern for `gh project item-create`. Inline `--body` with backticks fails on Windows.
+- Always use a single-quoted pwsh here-string + temp file + `Get-Content -Raw` for the body. Inline `--body "..."` with backticks fails on Windows. **Note:** `gh project item-create` does not support `--body-file` (verified 2026-04 against gh 2.90.0); you must read the file content into a variable and pass it via `--body`.
 - One draft per invocation. If the user proposes multiple roadmap items, file them one at a time so the field-setting calls in step 7 stay simple.
 - Do not invoke other agents (e.g. `@issue-resolver`) without explicit user approval in the same turn.


### PR DESCRIPTION
Follow-up to #77. Caught while dogfooding the new agent path against project #13.

`gh project item-create` (gh 2.90.0, 2026-04) only supports `--body`, not `--body-file` — unlike `gh issue create`. The freshly merged agent file used `--body-file` and would have failed on first real invocation with `unknown flag: --body-file`.

## Change

- Step 7 sub-step 1: read the temp file via `Get-Content -Raw` into a variable, pass it via `--body $bodyText`.
- Constraints note: call out the asymmetry between `gh issue create` and `gh project item-create` so future agent edits don't repeat the mistake.

## Evidence this is needed

While creating the C follow-up roadmap draft ("Automate draft-to-issue conversion from @project-intake chat"), the first attempt with `--body-file` returned:

```
unknown flag: --body-file
```

Worked on retry with `--body $bodyText`. Resulting draft is `PVTI_lAHOBvMdD84BVzLBzgrC7Lw` on project #13 with all four single-select fields set correctly (Status=Todo, Pillar=Cross-pillar, Tier=Standard, Priority=p2).

## Tested

- Re-read the agent file end-to-end after the edit.
- Repo memory recorded so future agent or script edits don't repeat the same mistake.
