### PR TITLE
Auto-label issues converted from project #13 drafts

### DIFF
--- a/.github/workflows/project-converted-issue.yml
+++ b/.github/workflows/project-converted-issue.yml
@@ -1,0 +1,106 @@
+name: Project converted-issue auto-label
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: project-converted-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  label-converted-issue:
+    name: Label issues that already live on project #13
+    runs-on: ubuntu-latest
+    # Skip issues opened with the Project label already applied — project-autoadd.yml
+    # handles those, and this workflow is the inverse direction (project-membership
+    # implies label, not label implies project-membership). If the label is already
+    # present we have nothing to add.
+    if: >-
+      !contains(github.event.issue.labels.*.name, 'Project')
+    steps:
+      - name: Probe project #13 membership and apply labels
+        env:
+          # Classic PAT with `project` scope. Same secret powers bug-autoadd.yml
+          # and project-autoadd.yml. The default GITHUB_TOKEN cannot read
+          # ProjectV2 fields on a user-owned project.
+          GH_TOKEN: ${{ secrets.BUG_PROJECT_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+
+          # Query: for this issue, list every project item it appears on,
+          # along with the parent project number and any single-select field
+          # values (we only care about Priority for now).
+          read -r -d '' QUERY <<'GRAPHQL' || true
+          query($owner: String!, $name: String!, $number: Int!) {
+            repository(owner: $owner, name: $name) {
+              issue(number: $number) {
+                projectItems(first: 20) {
+                  nodes {
+                    project { number }
+                    fieldValues(first: 30) {
+                      nodes {
+                        ... on ProjectV2ItemFieldSingleSelectValue {
+                          name
+                          field {
+                            ... on ProjectV2SingleSelectField { name }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          GRAPHQL
+
+          RESPONSE=$(gh api graphql \
+            -F owner="$OWNER" \
+            -F name="$REPO_NAME" \
+            -F number="$ISSUE_NUMBER" \
+            -f query="$QUERY")
+
+          # Find the project #13 item, if any.
+          ITEM=$(echo "$RESPONSE" | jq '.data.repository.issue.projectItems.nodes[] | select(.project.number == 13)')
+
+          if [ -z "$ITEM" ]; then
+            echo "Issue #$ISSUE_NUMBER is not on project #13. Nothing to do."
+            exit 0
+          fi
+
+          echo "Issue #$ISSUE_NUMBER is on project #13. Applying labels."
+
+          LABELS=("Project")
+
+          PRIORITY=$(echo "$ITEM" | jq -r '.fieldValues.nodes[] | select(.field.name == "Priority") | .name // empty')
+
+          case "$PRIORITY" in
+            p0|p1|p2|p3)
+              LABELS+=("priority:$PRIORITY")
+              echo "Project #13 Priority field = $PRIORITY -> adding priority:$PRIORITY"
+              ;;
+            "")
+              echo "Priority field not set on the project item; skipping priority label."
+              ;;
+            *)
+              echo "Priority field value '$PRIORITY' does not map to a priority:p<n> label; skipping."
+              ;;
+          esac
+
+          # gh issue edit accepts repeated --add-label flags; build the args.
+          ARGS=()
+          for L in "${LABELS[@]}"; do
+            ARGS+=(--add-label "$L")
+          done
+
+          gh issue edit "$ISSUE_NUMBER" \
+            --repo "$OWNER/$REPO_NAME" \
+            "${ARGS[@]}"


### PR DESCRIPTION
Closes #78.

## What this adds

A new workflow `.github/workflows/project-converted-issue.yml` that fires on `issues: [opened]`, queries Projects v2 GraphQL to see whether the new issue is already an item on project #13 (Security Portfolio Roadmap), and if so applies:

- The `Project` label.
- A `priority:p<n>` label matching the project item's `Priority` single-select field, if set to one of `p0`/`p1`/`p2`/`p3`.

This is the inverse direction of `project-autoadd.yml`:

| Workflow | Trigger | Direction |
|---|---|---|
| `project-autoadd.yml` | `Project` label added | label → project membership |
| `project-converted-issue.yml` | issue opened | project membership → labels |

Both are needed because the `@project-intake` agent's path creates DraftIssues directly on the project (drafts don't support labels). When the user later clicks "Convert to issue" in the project UI, the resulting real issue inherits the project field values but has no labels — so it's invisible to `gh issue list --label Project` and to label-driven views. This workflow closes that gap.

## Implementation notes

- Pinned `actions/add-to-project` is not used — there's no off-the-shelf action for "label issue based on project membership", so this is a small inline shell job using `gh api graphql` + `gh issue edit`.
- Uses the existing `BUG_PROJECT_TOKEN` classic PAT (also used by `bug-autoadd.yml` and `project-autoadd.yml`) because the default `GITHUB_TOKEN` cannot read `ProjectV2` fields on a user-owned project (per `userMemory/github-projects-tokens.md`).
- `permissions: contents: read, issues: write` — least-privilege.
- `if:` guard skips issues that already have the `Project` label so we don't re-trigger on label-driven opens (which `project-autoadd.yml` handles).
- No-op exit when the issue isn't on project #13 (handles all unrelated repo issues).

## Acceptance criteria

- [x] New workflow file created with pinned action SHAs (no third-party actions used; only first-party `gh` CLI inline) and explicit `permissions:` (`issues: write`, `contents: read`).
- [x] Uses `BUG_PROJECT_TOKEN` (existing classic PAT with `project` scope) for the GraphQL read.
- [ ] Smoke test: create a draft on project #13 with `Priority=p2`, convert it to an issue via the UI, verify the resulting issue ends up labeled `Project` and `priority:p2` within ~30s. **Deferred to user — requires manual UI action; can't be automated from the agent.**
- [x] No-op for issues that aren't on project #13 (don't apply the label spuriously) — handled by the `select(.project.number == 13)` filter and the empty-`ITEM` early exit.

## Tested

- `npm run lint` clean (htmlhint + stylelint, no errors).
- Workflow YAML syntax validated by GitHub Actions parser on push (workflow_run / lint pass on PR).

## Smoke-test instructions for the user

When ready to verify the deferred AC:

1. Open project #13 in the UI: <https://github.com/users/marcusjacobson/projects/13>.
2. Pick any existing draft (or use `@project-intake` to file a fresh one) and set its `Priority` field to `p2`.
3. Click the draft → "Convert to issue" → choose the `portfolio` repo.
4. Within ~30s, the new real issue should appear with labels `Project` and `priority:p2`.
5. If it doesn't, check the Actions tab for the `Project converted-issue auto-label` run on that issue's `opened` event.
