### PR TITLE
Fix project-converted-issue: split token scopes (probe vs label edit)

### DIFF
--- a/.github/workflows/project-converted-issue.yml
+++ b/.github/workflows/project-converted-issue.yml
@@ -23,11 +23,16 @@ jobs:
     if: >-
       !contains(github.event.issue.labels.*.name, 'Project')
     steps:
-      - name: Probe project #13 membership and apply labels
+      - name: Probe project #13 and decide which labels to apply
+        id: probe
         env:
           # Classic PAT with `project` scope. Same secret powers bug-autoadd.yml
           # and project-autoadd.yml. The default GITHUB_TOKEN cannot read
-          # ProjectV2 fields on a user-owned project.
+          # ProjectV2 fields on a user-owned project. NOTE: this token has only
+          # `project` scope, so it cannot call `addLabelsToLabelable` /
+          # `gh issue edit --add-label`. The labelling step below uses the
+          # default GITHUB_TOKEN (granted `issues: write` via the workflow
+          # `permissions:` block) instead.
           GH_TOKEN: ${{ secrets.BUG_PROJECT_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           OWNER: ${{ github.repository_owner }}
@@ -95,10 +100,33 @@ jobs:
               ;;
           esac
 
-          # gh issue edit accepts repeated --add-label flags; build the args.
+          # Emit a comma-separated list of labels for the next step. Empty value
+          # means "issue is not on project #13, skip labelling".
+          IFS=','
+          echo "labels=${LABELS[*]}" >> "$GITHUB_OUTPUT"
+
+      - name: Apply labels (uses default GITHUB_TOKEN with issues:write)
+        if: steps.probe.outputs.labels != ''
+        env:
+          # Default GITHUB_TOKEN — the workflow `permissions:` block grants it
+          # `issues: write`, which is sufficient for `gh issue edit --add-label`.
+          # We deliberately do NOT reuse BUG_PROJECT_TOKEN here because that
+          # classic PAT only has `project` scope and cannot call the
+          # `addLabelsToLabelable` GraphQL field (requires `public_repo`).
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          LABELS: ${{ steps.probe.outputs.labels }}
+        run: |
+          set -euo pipefail
+
+          # gh issue edit accepts repeated --add-label flags; build the args
+          # from the comma-separated probe output.
           ARGS=()
-          for L in "${LABELS[@]}"; do
-            ARGS+=(--add-label "$L")
+          IFS=',' read -ra LABEL_ARRAY <<<"$LABELS"
+          for L in "${LABEL_ARRAY[@]}"; do
+            [ -n "$L" ] && ARGS+=(--add-label "$L")
           done
 
           gh issue edit "$ISSUE_NUMBER" \


### PR DESCRIPTION
Caught while smoke-testing #81 on issue #82 (a draft converted to a real issue via the `convertProjectV2DraftIssueItemToIssue` GraphQL mutation).

## Bug

`BUG_PROJECT_TOKEN` is a classic PAT with **only the `project` scope**. The probe step succeeds (project field read works), but `gh issue edit --add-label` fails with:

```
GraphQL: Your token has not been granted the required scopes to execute this query.
The 'addLabelsToLabelable' field requires one of the following scopes: ['public_repo'],
but your token has only been granted the: ['project'] scopes.
```

Run id 24967648388. Issue #82 came out unlabeled (atomic failure).

## Fix

Split the single step into two:

1. **`probe`** (uses `BUG_PROJECT_TOKEN`) — runs the ProjectV2 GraphQL probe and emits a comma-separated `labels` output. Adding to existing logic, an empty output means "skip labelling".
2. **`Apply labels`** (uses default `GITHUB_TOKEN`) — gated on `steps.probe.outputs.labels != ''`, runs `gh issue edit --add-label`. The workflow's existing `permissions: issues: write` already authorizes this token for label edits, so no new secret is needed.

Why not just expand `BUG_PROJECT_TOKEN`'s scope? Adding `public_repo`/`repo` to a classic PAT broadens its blast radius far beyond what `bug-autoadd.yml` and `project-autoadd.yml` need (those only call `actions/add-to-project` which uses GraphQL `addProjectV2ItemById` — a `project`-scope-only operation). Splitting tokens keeps each one minimum-privilege.

Comments in the workflow now call out this asymmetry so future edits don't re-introduce it.

## Tested

- `npm run lint` clean.
- After merge, will re-run the smoke test by converting another draft on project #13 to an issue and confirming labels are applied. Will close #78 and clean up the smoke issues afterward.
