### PR TITLE
chore: rename Project label to Board and update workflow gates (#86)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -5,9 +5,9 @@
 - name: bug
   color: d73a4a
   description: Something is broken.
-- name: Project
+- name: Board
   color: 5319e7
-  description: Roadmap item tracked on the Security Portfolio Roadmap project board.
+  description: Issue belongs on a GitHub Projects v2 board (e.g. the Security Portfolio Roadmap board #13).
 - name: content-update
   color: 0e8a16
   description: Update existing portfolio content.

--- a/.github/workflows/project-autoadd.yml
+++ b/.github/workflows/project-autoadd.yml
@@ -14,16 +14,16 @@ concurrency:
 
 jobs:
   add-to-project:
-    name: Add Project-labeled issue to Security Portfolio Roadmap
+    name: Add Board-labeled issue to Security Portfolio Roadmap
     runs-on: ubuntu-latest
     if: >-
-      (github.event.action == 'labeled' && github.event.label.name == 'Project') ||
-      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'Project'))
+      (github.event.action == 'labeled' && github.event.label.name == 'Board') ||
+      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'Board'))
     steps:
-      - name: Add issue to project #13
+      - name: Add issue to board #13
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/users/marcusjacobson/projects/13
           # Reuses the classic-PAT secret that already powers bug-autoadd.yml.
-          # Project scope on the same user-owned account covers project #13.
+          # Project scope on the same user-owned account covers board #13.
           github-token: ${{ secrets.BUG_PROJECT_TOKEN }}

--- a/.github/workflows/project-converted-issue.yml
+++ b/.github/workflows/project-converted-issue.yml
@@ -14,16 +14,16 @@ concurrency:
 
 jobs:
   label-converted-issue:
-    name: Label issues that already live on project #13
+    name: Label issues that already live on board #13
     runs-on: ubuntu-latest
-    # Skip issues opened with the Project label already applied — project-autoadd.yml
-    # handles those, and this workflow is the inverse direction (project-membership
-    # implies label, not label implies project-membership). If the label is already
+    # Skip issues opened with the Board label already applied — project-autoadd.yml
+    # handles those, and this workflow is the inverse direction (board-membership
+    # implies label, not label implies board-membership). If the label is already
     # present we have nothing to add.
     if: >-
-      !contains(github.event.issue.labels.*.name, 'Project')
+      !contains(github.event.issue.labels.*.name, 'Board')
     steps:
-      - name: Probe project #13 and decide which labels to apply
+      - name: Probe board #13 and decide which labels to apply
         id: probe
         env:
           # Classic PAT with `project` scope. Same secret powers bug-autoadd.yml
@@ -73,27 +73,27 @@ jobs:
             -F number="$ISSUE_NUMBER" \
             -f query="$QUERY")
 
-          # Find the project #13 item, if any.
+          # Find the board #13 item, if any.
           ITEM=$(echo "$RESPONSE" | jq '.data.repository.issue.projectItems.nodes[] | select(.project.number == 13)')
 
           if [ -z "$ITEM" ]; then
-            echo "Issue #$ISSUE_NUMBER is not on project #13. Nothing to do."
+            echo "Issue #$ISSUE_NUMBER is not on board #13. Nothing to do."
             exit 0
           fi
 
-          echo "Issue #$ISSUE_NUMBER is on project #13. Applying labels."
+          echo "Issue #$ISSUE_NUMBER is on board #13. Applying labels."
 
-          LABELS=("Project")
+          LABELS=("Board")
 
           PRIORITY=$(echo "$ITEM" | jq -r '.fieldValues.nodes[] | select(.field.name == "Priority") | .name // empty')
 
           case "$PRIORITY" in
             p0|p1|p2|p3)
               LABELS+=("priority:$PRIORITY")
-              echo "Project #13 Priority field = $PRIORITY -> adding priority:$PRIORITY"
+              echo "Board #13 Priority field = $PRIORITY -> adding priority:$PRIORITY"
               ;;
             "")
-              echo "Priority field not set on the project item; skipping priority label."
+              echo "Priority field not set on the board item; skipping priority label."
               ;;
             *)
               echo "Priority field value '$PRIORITY' does not map to a priority:p<n> label; skipping."
@@ -101,7 +101,7 @@ jobs:
           esac
 
           # Emit a comma-separated list of labels for the next step. Empty value
-          # means "issue is not on project #13, skip labelling".
+          # means "issue is not on board #13, skip labelling".
           IFS=','
           echo "labels=${LABELS[*]}" >> "$GITHUB_OUTPUT"
 

--- a/wiki/Terminology.md
+++ b/wiki/Terminology.md
@@ -23,7 +23,7 @@ A **Board** is a GitHub Projects v2 board used for planning, triage, or roadmap 
 | `ms_security_projects.html` | Portfolio (Project) | Repo root, served by GitHub Pages |
 | "the Bug Tracker board" | Board | GitHub Projects v2 |
 | "the Compass v-next board" | Board | GitHub Projects v2 |
-| The `Project` label | Board (signals "add this issue to a Board") | Repo labels — currently named `Project`, will be renamed to `Board` in #86. Until then, treat the label name as historical, not authoritative. |
+| The `Board` label | Board (signals "add this issue to a Board") | Repo labels — renamed from `Project` to `Board` in #86 to keep "Project" exclusive to portfolio work. |
 | "Microsoft Security Portfolio Roadmap" (#13) | A Board that tracks Projects | GitHub Projects v2 |
 
 ## Why the split


### PR DESCRIPTION
## Summary

Renames the `Project` repo label to `Board` and updates label-driven workflows to gate on `Board`. Part 2 of the Board Terminology Split (#85–#91). Keeps the `Project` noun exclusive to the portfolio (the live site / `ms_security_projects.html`) and aligns the GitHub-side concept with the GitHub UI metaphor.

## Changes

- `.github/labels.yml`: `Project` → `Board`, refreshed description.
- `.github/workflows/project-autoadd.yml`: gate on `Board` label, comments updated.
- `.github/workflows/project-converted-issue.yml`: probe-then-apply split-token pattern preserved (BUG_PROJECT_TOKEN scope-limit comments untouched); shell `LABELS=("Project")` → `LABELS=("Board")`; comments updated to "board #13".
- `wiki/Terminology.md`: row updated to reflect completed rename.
- Live GitHub label rename via API (preserves history):
  ```
  gh api repos/marcusjacobson/portfolio/labels/Project --method PATCH \
    -f new_name=Board \
    -f description='Issue belongs on a GitHub Projects v2 board (e.g. the Security Portfolio Roadmap board #13).'
  ```
  `gh label list` confirms only `Board` exists post-rename.

## Out of scope (deferred)

- #87 — agent file renames (`@project-intake` etc.)
- #88 — script renames under `scripts/gh/`
- #89 — workflow filename renames (`project-autoadd.yml` etc.)
- #90 — split `wiki/Projects.md`

## Tested

- [x] `gh api ... PATCH new_name=Board` returned 200 with the new label payload.
- [x] `gh label list` shows `Board` only — no `Project` remnant.
- [x] Workflows still parse (YAML structure untouched apart from label string + comments).
- [x] Split-token pattern (BUG_PROJECT_TOKEN probe + default GITHUB_TOKEN apply) preserved.
- [ ] Post-merge smoke test (open issue with `Board` label → autoadd to board #13) — performed after merge per AC4.

Closes #86
