### PR TITLE
chore(scripts): rename project scripts to *-board with shims (#88)

### DIFF
--- a/.github/agents/board-planner.agent.md
+++ b/.github/agents/board-planner.agent.md
@@ -1,5 +1,5 @@
 ---
-description: "Use to scope and create a GitHub board (Projects v2) from a theme, milestone, or cluster of issues. Decides if a new board is warranted, designs fields and views, runs scripts/gh/create-project.ps1, and seeds items via add-issue-to-project.ps1."
+description: "Use to scope and create a GitHub board (Projects v2) from a theme, milestone, or cluster of issues. Decides if a new board is warranted, designs fields and views, runs scripts/gh/create-board.ps1, and seeds items via add-issue-to-board.ps1."
 readme-summary: "Scopes and creates a GitHub board (Projects v2) from a theme or cluster of issues. Designs fields/views and seeds items via `scripts/gh/`."
 tools: [read, edit, search, execute, github/*, todo]
 ---
@@ -30,10 +30,10 @@ Accept any one of:
    - **Status values:** Backlog → Ready → In progress → In review → Done.
    - **Views:** at minimum a Board grouped by Status and a Table sorted by Priority.
 4. **Discover items.** Resolve the input into concrete issue URLs via `gh issue list --label <l> --state open --json number,url,title`. For unbacked ideas, draft issue titles + bodies and (with user OK) create them via `gh issue create --body-file <tmp>` using the pwsh body-file pattern.
-5. **Create the board.** Run `scripts/gh/create-project.ps1 -Title "<title>"`. Capture the board URL.
+5. **Create the board.** Run `scripts/gh/create-board.ps1 -Title "<title>"`. Capture the board URL.
 6. **Link to the repo.** Run `gh project link <number> --owner <owner> --repo <owner>/<repo>` so the board appears under the repo's **Projects** tab. Projects v2 are owned at the user/org level — linking is what surfaces them on the repo.
 7. **Apply the schema.** Use `gh project field-create` for each field that the script doesn't seed. Default fields (Title, Status, Assignees) come for free.
-8. **Seed items.** For each issue URL, run `scripts/gh/add-issue-to-project.ps1 -ProjectUrl <url> -ItemUrl <issue-url>`.
+8. **Seed items.** For each issue URL, run `scripts/gh/add-issue-to-board.ps1 -BoardUrl <url> -ItemUrl <issue-url>`.
 9. **Document.** Add a short `wiki/Projects.md` entry (or update the existing one) with: title, link, scope, success criteria, and a link to the seeding command run. Open a PR for the wiki edit.
 10. **Report.**
 

--- a/.github/agents/bug-intake.agent.md
+++ b/.github/agents/bug-intake.agent.md
@@ -201,7 +201,7 @@ Run, in order, echoing each command:
    ```
 2. **Add to project** if a bug project exists and the user approved:
    ```pwsh
-   scripts/gh/add-issue-to-project.ps1 -ProjectUrl <url> -ItemUrl <issue-url>
+   scripts/gh/add-issue-to-board.ps1 -BoardUrl <url> -ItemUrl <issue-url>
    ```
    Or, if the script is missing, use `gh project item-add <projectNumber> --owner marcusjacobson --url <issue-url>`.
 3. **Set project fields** if known (Priority, Severity, Status). Use `gh project item-edit` with the field id captured in step 2's discovery.

--- a/.github/agents/request-intake.agent.md
+++ b/.github/agents/request-intake.agent.md
@@ -181,7 +181,7 @@ These steps are **mandatory and ordered** on every confirmed intake. Do not skip
    - This step runs **even when this agent is not the implementer** — it guarantees that whoever picks up the issue (the user, `issue-resolver`, `boards-worker`) starts on a non-`main` branch.
 3. **Add to project** if approved:
    ```pwsh
-   scripts/gh/add-issue-to-project.ps1 -ProjectUrl <url> -ItemUrl <issue-url>
+   scripts/gh/add-issue-to-board.ps1 -BoardUrl <url> -ItemUrl <issue-url>
    ```
    Or, if the script is missing, use `gh project item-add <projectNumber> --owner marcusjacobson --url <issue-url>`.
 4. **Set project fields** if known (Priority, Size). Use `gh project item-edit` with the field id captured in step 2's discovery.

--- a/scripts/gh/add-issue-to-board.ps1
+++ b/scripts/gh/add-issue-to-board.ps1
@@ -1,0 +1,23 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Add a GitHub issue or PR to a board (Projects v2) by URL.
+.DESCRIPTION
+    Resolves the project number and owner from -BoardUrl, then calls
+    `gh project item-add <number> --owner <owner> --url <ItemUrl>`.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$BoardUrl,
+    [Parameter(Mandatory)][string]$ItemUrl
+)
+$ErrorActionPreference = 'Stop'
+
+# Expect URLs of the form https://github.com/(users|orgs)/<owner>/projects/<number>
+if ($BoardUrl -notmatch 'github\.com/(?:users|orgs)/(?<owner>[^/]+)/projects/(?<number>\d+)') {
+    throw "BoardUrl is not a Projects v2 URL: $BoardUrl"
+}
+$owner = $Matches.owner
+$number = [int]$Matches.number
+
+gh project item-add $number --owner $owner --url $ItemUrl

--- a/scripts/gh/add-issue-to-project.ps1
+++ b/scripts/gh/add-issue-to-project.ps1
@@ -1,23 +1,20 @@
 #Requires -Version 7.0
 <#
 .SYNOPSIS
-    Add a GitHub issue or PR to a Project (v2) by URL.
+    DEPRECATED shim. Forwards to scripts/gh/add-issue-to-board.ps1.
 .DESCRIPTION
-    Resolves the project number and owner from -ProjectUrl, then calls
-    `gh project item-add <number> --owner <owner> --url <ItemUrl>`.
+    Renamed as part of the GitHub Projects v2 → "board" terminology split.
+    The -ProjectUrl parameter is renamed to -BoardUrl in the new script;
+    this shim still accepts -ProjectUrl for back-compat and forwards it.
+    This shim will be removed on or after 2026-07-01 (tracked in issue #91).
 #>
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)][string]$ProjectUrl,
     [Parameter(Mandatory)][string]$ItemUrl
 )
-$ErrorActionPreference = 'Stop'
 
-# Expect URLs of the form https://github.com/(users|orgs)/<owner>/projects/<number>
-if ($ProjectUrl -notmatch 'github\.com/(?:users|orgs)/(?<owner>[^/]+)/projects/(?<number>\d+)') {
-    throw "ProjectUrl is not a Projects v2 URL: $ProjectUrl"
-}
-$owner = $Matches.owner
-$number = [int]$Matches.number
+Write-Warning "scripts/gh/add-issue-to-project.ps1 is deprecated and will be removed on or after 2026-07-01. Use scripts/gh/add-issue-to-board.ps1 with -BoardUrl instead."
 
-gh project item-add $number --owner $owner --url $ItemUrl
+$forward = Join-Path $PSScriptRoot 'add-issue-to-board.ps1'
+& $forward -BoardUrl $ProjectUrl -ItemUrl $ItemUrl

--- a/scripts/gh/create-board.ps1
+++ b/scripts/gh/create-board.ps1
@@ -1,0 +1,30 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Create a GitHub board (Projects v2) for the repo if it doesn't exist
+    and link it to the repo.
+.PARAMETER Owner
+    User or org owner. Defaults to the current repo owner.
+.PARAMETER Title
+    Board title. Default: "Portfolio".
+#>
+[CmdletBinding()]
+param(
+    [string]$Owner,
+    [string]$Title = 'Portfolio'
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw "gh CLI required." }
+if (-not $Owner) { $Owner = (gh repo view --json owner -q .owner.login) }
+
+$existing = gh project list --owner $Owner --format json | ConvertFrom-Json
+$match = $existing.projects | Where-Object { $_.title -eq $Title }
+
+if ($match) {
+    Write-Host "Board '$Title' already exists: $($match.url)" -ForegroundColor Yellow
+} else {
+    Write-Host "Creating board '$Title' under $Owner..."
+    $created = gh project create --owner $Owner --title $Title --format json | ConvertFrom-Json
+    Write-Host "Created: $($created.url)" -ForegroundColor Green
+}

--- a/scripts/gh/create-project.ps1
+++ b/scripts/gh/create-project.ps1
@@ -1,12 +1,10 @@
 #Requires -Version 7.0
 <#
 .SYNOPSIS
-    Create the "Portfolio" GitHub Project (v2) for the repo if it doesn't exist
-    and link it to the repo.
-.PARAMETER Owner
-    User or org owner. Defaults to the current repo owner.
-.PARAMETER Title
-    Project title. Default: "Portfolio".
+    DEPRECATED shim. Forwards to scripts/gh/create-board.ps1.
+.DESCRIPTION
+    Renamed as part of the GitHub Projects v2 → "board" terminology split.
+    This shim will be removed on or after 2026-07-01 (tracked in issue #91).
 #>
 [CmdletBinding()]
 param(
@@ -14,17 +12,9 @@ param(
     [string]$Title = 'Portfolio'
 )
 
-$ErrorActionPreference = 'Stop'
-if (-not (Get-Command gh -ErrorAction SilentlyContinue)) { throw "gh CLI required." }
-if (-not $Owner) { $Owner = (gh repo view --json owner -q .owner.login) }
+Write-Warning "scripts/gh/create-project.ps1 is deprecated and will be removed on or after 2026-07-01. Use scripts/gh/create-board.ps1 instead."
 
-$existing = gh project list --owner $Owner --format json | ConvertFrom-Json
-$match = $existing.projects | Where-Object { $_.title -eq $Title }
-
-if ($match) {
-    Write-Host "Project '$Title' already exists: $($match.url)" -ForegroundColor Yellow
-} else {
-    Write-Host "Creating project '$Title' under $Owner..."
-    $created = gh project create --owner $Owner --title $Title --format json | ConvertFrom-Json
-    Write-Host "Created: $($created.url)" -ForegroundColor Green
-}
+$forward = Join-Path $PSScriptRoot 'create-board.ps1'
+$splat = @{ Title = $Title }
+if ($Owner) { $splat.Owner = $Owner }
+& $forward @splat


### PR DESCRIPTION
## Summary

Renames the two GitHub Projects v2 scripts to use "board" terminology, adds back-compat shims at the old paths, and updates forward-looking callers in agent docs.

## Changes

- `scripts/gh/create-project.ps1` → `create-board.ps1` (semantics preserved; default `-Title "Portfolio"`).
- `scripts/gh/add-issue-to-project.ps1` → `add-issue-to-board.ps1`; param `-ProjectUrl` → `-BoardUrl`.
- Deprecation shims at the old paths emit `Write-Warning` and forward (removal target: 2026-07-01, tracked in #91). The shim accepts the old `-ProjectUrl` name and translates to `-BoardUrl` for callers that have not migrated.
- Updated forward-looking refs in `.github/agents/board-planner.agent.md`, `bug-intake.agent.md`, `request-intake.agent.md`. Historical entries in `wiki/Projects.md` left verbatim as audit record.

## Acceptance criteria

- [x] `create-project.ps1` → `create-board.ps1`; default `-Title` semantics preserved.
- [x] `add-issue-to-project.ps1` → `add-issue-to-board.ps1`; param `-ProjectUrl` → `-BoardUrl`.
- [x] Shim wrappers forward + warn with removal date.
- [x] Forward-looking callers updated in agents.
- [x] Smoke run: `pwsh -NoProfile -File scripts/gh/add-issue-to-board.ps1 -BoardUrl <url> -ItemUrl <url>` succeeds against board #14 (issue 88, exit 0).

Closes #88.
