### PR TITLE
boards-worker session: Board Terminology Split resume (2026-04-26)

### DIFF
--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -38,7 +38,12 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #90 Ready → In progress at 2026-04-26T19:05:47-07:00
   - #90 In progress → Done — PR #99, merge `052de86`
 - **Mid-flight scope correction:** main's `wiki/Projects.md` audit log moved to `wiki/Boards.md` while #90 was in flight. Session branch was reset to main and this consolidated entry rewritten directly against `wiki/Boards.md` (the new canonical home) rather than rebasing the now-stale per-issue commits.
-- **Outcome:** _(in flight — #90 just shipped; halting before #91 per default `--max=3`. #91 explicitly removes deprecation shims introduced by #88, so it must be the last issue in the rollout and requires separate user approval.)_
+- **Mid-flight intake (read-only sweep):** before approving #91, user requested a thorough repo-wide sweep for "project" vs "board" prose drift under the canonical rule (Project = portfolio work item; Board = GitHub Projects v2 container). User clarified the `Project` label should be **restored** (not folded into `Board`) so it can keep tagging issues that track a portfolio Project the user is working on. Sweep filed 4 follow-on issues onto board #14 with `Status=Ready`:
+  - #100 Restore `Project` label and rewire `@project-intake` to use it (priority:p1) — `PVTI_lAHOBvMdD84BVzd8zgrEQ58`
+  - #101 Fix project/board prose drift in intake and repo-ops agents (priority:p2) — `PVTI_lAHOBvMdD84BVzd8zgrEQ6c`
+  - #102 Fix project/board prose drift in copilot-instructions, prompts, and workflows (priority:p3) — `PVTI_lAHOBvMdD84BVzd8zgrEQ7I`
+  - #103 Refresh `agents/README.md` description for `@project-intake` (priority:p3) — `PVTI_lAHOBvMdD84BVzd8zgrEQ7U`
+- **Outcome:** _(in flight — #88/#89/#90 shipped; #100–#103 added to queue as Ready; halting before #91 per default `--max=3`. #91 explicitly removes deprecation shims introduced by #88, so it must be the last shim-related issue in the rollout and requires separate user approval. Suggested execution after #91: #100 → #101/#102 (parallel) → #103.)_
 
 ### 2026-04-26 — projects-worker session: Board Terminology Split (#14)
 

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -23,6 +23,23 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 
 ## Sweep log
 
+### 2026-04-26 — boards-worker session: Board Terminology Split (#14) — resume
+
+- **Branch:** `boards-worker/board-terminology-split-20260426-1900` — PR pending
+- **Operator:** boards-worker agent
+- **Queue at start (Ready):** #88, #89, #90, #91 (resume after #85–#87 shipped via prior session; default `--max=3` so this batch covers #88, #89, #90 and halts before #91)
+- **Status field options captured:** Ready=`f75ad846`, In progress=`47fc9ee4`, In review=`2aee1b22`, Done=`98236657`
+- **Schema mutations applied:** _(none — schema already correct from prior session)_
+- **Per-issue transitions:**
+  - #88 Ready → In progress at 2026-04-26T18:55:21-07:00
+  - #88 In progress → Done — PR #97, merge `e69d859`
+  - #89 Ready → In progress at 2026-04-26T19:00:56-07:00
+  - #89 In progress → Done — PR #98, merge `817a43f`
+  - #90 Ready → In progress at 2026-04-26T19:05:47-07:00
+  - #90 In progress → Done — PR #99, merge `052de86`
+- **Mid-flight scope correction:** main's `wiki/Projects.md` audit log moved to `wiki/Boards.md` while #90 was in flight. Session branch was reset to main and this consolidated entry rewritten directly against `wiki/Boards.md` (the new canonical home) rather than rebasing the now-stale per-issue commits.
+- **Outcome:** _(in flight — #90 just shipped; halting before #91 per default `--max=3`. #91 explicitly removes deprecation shims introduced by #88, so it must be the last issue in the rollout and requires separate user approval.)_
+
 ### 2026-04-26 — projects-worker session: Board Terminology Split (#14)
 
 - **Branch:** `projects-worker/board-terminology-split-20260426-1507` — PR pending


### PR DESCRIPTION
Audit-log entry for the resumed Board Terminology Split session.

## Session summary

| # | Title | PR | Merge |
|---|---|---|---|
| #88 | Add Board label and board-autoadd workflow with shims | [#97](https://github.com/marcusjacobson/portfolio/pull/97) | `e69d859` |
| #89 | Rename agents and prompts | [#98](https://github.com/marcusjacobson/portfolio/pull/98) | `817a43f` |
| #90 | Move audit log from wiki/Projects.md to wiki/Boards.md | [#99](https://github.com/marcusjacobson/portfolio/pull/99) | `052de86` |

## Mid-flight intake (read-only sweep, no code changes)

Before approving #91, the user requested a thorough repo-wide sweep for `project` vs `board` prose drift under the canonical rule (Project = portfolio work item; Board = GitHub Projects v2 container). User clarified the `Project` label should be **restored** (not folded into `Board`) so it can keep tagging issues that track a portfolio Project the user is working on.

Sweep filed 4 follow-on issues onto board #14 with `Status=Ready`:

- #100 Restore `Project` label and rewire `@project-intake` to use it (priority:p1)
- #101 Fix project/board prose drift in intake and repo-ops agents (priority:p2)
- #102 Fix project/board prose drift in copilot-instructions, prompts, and workflows (priority:p3)
- #103 Refresh `agents/README.md` description for `@project-intake` (priority:p3)

## What this PR contains

Audit-log updates only (`wiki/Boards.md`):

- Open + close entries for #88/#89/#90.
- Mid-flight scope correction noting the audit-log home moved from `wiki/Projects.md` to `wiki/Boards.md`.
- Mid-flight intake entry recording the sweep + #100–#103.

No source/code changes — those shipped via #97, #98, #99.

## Tested

- `gh project item-list 14` shows #88/#89/#90 in Done and #100–#103 in Ready.
- `gh label list` confirms `Board` exists; #100 will restore `Project`.
