### PR TITLE
Restore Project label and clarify intake label guidance

### DIFF
--- a/.github/agents/project-intake.agent.md
+++ b/.github/agents/project-intake.agent.md
@@ -119,9 +119,12 @@ Acceptance-criteria-style "Next steps" rules:
 
 ### Labels (n/a for drafts)
 
-DraftIssues cannot carry labels — labels are a Repository Issue feature and the GraphQL `DraftIssue` type has no labels field. Skip label selection for this path entirely. The `Board` label is reserved for *real* issues filed outside this agent (those are auto-added via `.github/workflows/board-autoadd.yml`).
+DraftIssues cannot carry labels — labels are a Repository Issue feature and the GraphQL `DraftIssue` type has no labels field. Skip label selection for this path entirely.
 
-If and when the user later clicks **Convert to issue** in the project UI, they may apply the `Project` label to the resulting real issue for label hygiene, but the item is already on the board so it's optional.
+The two relevant repo labels are orthogonal and only matter once a draft has been **Converted to issue**:
+
+- **`Project`** — marks the resulting real issue as tracking a portfolio Project the owner is working on. Apply this label after conversion for label hygiene; it is the canonical marker for portfolio work even though the item is already on the roadmap board.
+- **`Board`** — reserved for *real* issues filed outside this agent and auto-added to a board via `.github/workflows/board-autoadd.yml`. Items created through this agent are already on project #13, so the `Board` label is redundant on the converted issue and should not be applied here.
 
 ### Pillar values (must match project #13 field options exactly)
 

--- a/wiki/Terminology.md
+++ b/wiki/Terminology.md
@@ -23,7 +23,8 @@ A **Board** is a GitHub Projects v2 board used for planning, triage, or roadmap 
 | `ms_security_projects.html` | Portfolio (Project) | Repo root, served by GitHub Pages |
 | "the Bug Tracker board" | Board | GitHub Projects v2 |
 | "the Compass v-next board" | Board | GitHub Projects v2 |
-| The `Board` label | Board (signals "add this issue to a Board") | Repo labels — renamed from `Project` to `Board` in #86 to keep "Project" exclusive to portfolio work. |
+| The `Project` label | Portfolio (Project) — marks an issue as tracking a portfolio Project the owner is working on | Repo labels — restored in #100 after being mistakenly renamed to `Board` in #86. Orthogonal to the `Board` label. |
+| The `Board` label | Board (signals "auto-add this issue to a GitHub Projects v2 Board") | Repo labels — drives `.github/workflows/board-autoadd.yml`. Coexists with `Project`; an issue may carry one, the other, both, or neither. |
 | "Microsoft Security Portfolio Roadmap" (#13) | A Board that tracks Projects | GitHub Projects v2 |
 
 ## Why the split


### PR DESCRIPTION
Restores the Project label (color 0e8a16, distinct from Board's 5319e7) after the mistaken rename in #86. Project marks issues tracking portfolio work; Board drives auto-add to a Projects v2 board. They are orthogonal.

Updates wiki/Terminology.md Quick reference to document both labels and their distinct purposes, and rewrites the project-intake agent's Labels section to clarify when each label applies on the converted-issue path.

Closes #100
