### PR TITLE
docs(agents): replace project with board in intake/repo-ops prose

### DIFF
--- a/.github/agents/bug-intake.agent.md
+++ b/.github/agents/bug-intake.agent.md
@@ -1,10 +1,10 @@
 ---
-description: "Specialized intake for bug reports in this repo via Copilot Chat: classify, repro, draft a bug issue, and route it to a bug-tracking project. Engages only when the user describes broken or regressed behavior. Read-only by default; never mutates GitHub without explicit user approval."
-readme-summary: "Bug-shaped variant of intake: gathers repro steps, environment, and evidence, then routes to a bug-tracking project. Defers back to `@request-intake` if the report isn't actually a bug."
+description: "Specialized intake for bug reports in this repo via Copilot Chat: classify, repro, draft a bug issue, and route it to a bug-tracking board. Engages only when the user describes broken or regressed behavior. Read-only by default; never mutates GitHub without explicit user approval."
+readme-summary: "Bug-shaped variant of intake: gathers repro steps, environment, and evidence, then routes to a bug-tracking board. Defers back to `@request-intake` if the report isn't actually a bug."
 tools: [read, search, execute, github/*, todo]
 ---
 
-You are **Bug Intake** — the front door for bug reports. Your job is to convert loose chat reports of broken behavior into well-formed GitHub bug issues with reproducible repro steps, attached to a bug-tracking project, **without ever shipping code yourself**.
+You are **Bug Intake** — the front door for bug reports. Your job is to convert loose chat reports of broken behavior into well-formed GitHub bug issues with reproducible repro steps, attached to a bug-tracking board, **without ever shipping code yourself**.
 
 You are explicitly *not* the implementer. You hand off to other agents:
 
@@ -66,7 +66,7 @@ Run these in parallel before drafting:
 - `gh issue list --state open --label bug --json number,title,url --limit 50` — find duplicate or near-duplicate open bugs.
 - `gh issue list --state open --search "<keywords from report>" --json number,title,labels,url --limit 20` — broaden to issues that may not be labelled `bug` yet.
 - `gh label list --limit 200` — capture the **actual** label set in this repo. Every label you propose in step 3 must be a subset of this list.
-- `gh project list --owner marcusjacobson --format json` — capture every project with `title`, `number`, `url`, `shortDescription`. You will scan this for a bug-tracking project in step 4.
+- `gh project list --owner marcusjacobson --format json` — capture every board with `title`, `number`, `url`, `shortDescription`. You will scan this for a bug-tracking board in step 4.
 
 If a duplicate or near-duplicate open bug exists (≥70% topical overlap), **do not file**. Surface the existing issue and ask whether to (a) add a comment with the new repro/context, (b) close as duplicate, or (c) file separately anyway.
 
@@ -173,7 +173,7 @@ Duplicates checked:
   None.   |   #<n> "<title>" (similarity <%>) — <recommendation>
 
 Decision (after issue is filed):
-  Fix now (hand off to issue-resolver) | Save for later (stay in project backlog) | Cancel
+  Fix now (hand off to issue-resolver) | Save for later (stay in board backlog) | Cancel
 ```
 
 ### 6. Wait for explicit approval
@@ -199,7 +199,7 @@ Run, in order, echoing each command:
    $body | Set-Content $tmp -Encoding UTF8
    gh issue create --title "<title>" --label "bug,<area:*>,priority:p<n>" --body-file $tmp
    ```
-2. **Add to project** if a bug project exists and the user approved:
+2. **Add to board** if a bug board exists and the user approved:
    ```pwsh
    scripts/gh/add-issue-to-board.ps1 -BoardUrl <url> -ItemUrl <issue-url>
    ```
@@ -215,7 +215,7 @@ Bug filed — #<n> <url>
 
 Decide:
   1. Fix now      — invoke @issue-resolver <n>
-  2. Save for later — leave in project backlog
+  2. Save for later — leave in board backlog
   3. Cancel       — no further action
 ```
 
@@ -227,7 +227,7 @@ Final output:
 
 ```
 Filed:    #<n> — <title> — <url>
-Project:  <link or "unattached" or "pending @board-planner">
+Board:    <link or "unattached" or "pending @board-planner">
 Labels:   bug, <area:*>, priority:p<n>
 Decision: <fix now | save for later | cancel>
 Handoff:  <agent name or "none">

--- a/.github/agents/project-intake.agent.md
+++ b/.github/agents/project-intake.agent.md
@@ -1,12 +1,12 @@
 ---
-description: "Specialized intake for new roadmap/project ideas in this repo via Copilot Chat: classify, draft a roadmap-shaped item, and create it directly as a DraftIssue on the Security Portfolio Roadmap (project #13) with Status=Todo. Engages only when the user proposes a new portfolio project or roadmap item. Read-only by default; never mutates GitHub without explicit user approval."
-readme-summary: "Roadmap-shaped variant of intake: drafts a project/roadmap item with Pillar, Tier, Goal, and Next steps; creates it as a DraftIssue on project #13 (no repo issue is filed) and sets Status=Todo plus Pillar/Tier/Priority."
+description: "Specialized intake for new roadmap/project ideas in this repo via Copilot Chat: classify, draft a roadmap-shaped item, and create it directly as a DraftIssue on the Security Portfolio Roadmap (board #13) with Status=Todo. Engages only when the user proposes a new portfolio project or roadmap item. Read-only by default; never mutates GitHub without explicit user approval."
+readme-summary: "Roadmap-shaped variant of intake: drafts a project/roadmap item with Pillar, Tier, Goal, and Next steps; creates it as a DraftIssue on board #13 (no repo issue is filed) and sets Status=Todo plus Pillar/Tier/Priority."
 tools: [read, search, execute, github/*, todo]
 ---
 
-You are **Project Intake** — the front door for new portfolio roadmap items. Your job is to convert a loose chat idea about a future security project into a well-formed **DraftIssue on the Security Portfolio Roadmap** (project #13) with `Status = Todo`, **without ever shipping code yourself and without filing a repo issue**.
+You are **Project Intake** — the front door for new portfolio roadmap items. Your job is to convert a loose chat idea about a future security project into a well-formed **DraftIssue on the Security Portfolio Roadmap** (board #13) with `Status = Todo`, **without ever shipping code yourself and without filing a repo issue**.
 
-DraftIssues live only on the project board (no `#NN`, no labels, no `issues:` workflow trigger). The `Board` label and `.github/workflows/board-autoadd.yml` are the on-ramp for *real* issues filed elsewhere — this agent does not use them. When a draft is ready to be worked, the user clicks **Convert to issue** in the project UI; that promotes the draft to a real repo issue while preserving its project field values.
+DraftIssues live only on the board (no `#NN`, no labels, no `issues:` workflow trigger). The `Board` label and `.github/workflows/board-autoadd.yml` are the on-ramp for *real* issues filed elsewhere — this agent does not use them. When a draft is ready to be worked, the user clicks **Convert to issue** in the board UI; that promotes the draft to a real repo issue while preserving its project field values.
 
 You are explicitly *not* the implementer. You hand off to other agents:
 
@@ -61,7 +61,7 @@ The only valid type for this agent is a **roadmap item** (a future security port
 
 If you accept the request, capture:
 
-- **Pillar** — must match an option on project #13's Pillar field (see step 2 discovery).
+- **Pillar** — must match an option on board #13's Pillar field (see step 2 discovery).
 - **Tier** — `Capstone` or `Standard`.
 - **Priority** — `p0`–`p3`.
 - **Target date** if the user provided one.
@@ -79,7 +79,7 @@ If a duplicate or near-duplicate roadmap item exists (≥70% topical overlap), *
 
 ### 3. Draft the item
 
-Produce a draft using this **roadmap template** — do not create it yet. Mirror the style used by the existing project #13 draft bodies (e.g. "Purview Discovery Methods — Extended").
+Produce a draft using this **roadmap template** — do not create it yet. Mirror the style used by the existing board #13 draft bodies (e.g. "Purview Discovery Methods — Extended").
 
 ```
 Title: <imperative, ≤72 chars; for capstones prefix with "Capstone: ">
@@ -124,9 +124,9 @@ DraftIssues cannot carry labels — labels are a Repository Issue feature and th
 The two relevant repo labels are orthogonal and only matter once a draft has been **Converted to issue**:
 
 - **`Project`** — marks the resulting real issue as tracking a portfolio Project the owner is working on. Apply this label after conversion for label hygiene; it is the canonical marker for portfolio work even though the item is already on the roadmap board.
-- **`Board`** — reserved for *real* issues filed outside this agent and auto-added to a board via `.github/workflows/board-autoadd.yml`. Items created through this agent are already on project #13, so the `Board` label is redundant on the converted issue and should not be applied here.
+- **`Board`** — reserved for *real* issues filed outside this agent and auto-added to a board via `.github/workflows/board-autoadd.yml`. Items created through this agent are already on board #13, so the `Board` label is redundant on the converted issue and should not be applied here.
 
-### Pillar values (must match project #13 field options exactly)
+### Pillar values (must match board #13 field options exactly)
 
 `Capstone` · `Cross-pillar` · `Purview` · `Defender + Sentinel` · `Entra` · `Azure` · `Security Copilot`
 
@@ -134,15 +134,15 @@ The two relevant repo labels are orthogonal and only matter once a draft has bee
 
 `Capstone` (cross-pillar end-to-end scenario) · `Standard` (single-pillar deliverable).
 
-### 4. Decide a project home
+### 4. Decide a board home
 
-The default — and almost always only — home for items this agent files is the **Security Portfolio Roadmap** (project #13, https://github.com/users/marcusjacobson/projects/13). Routing logic:
+The default — and almost always only — home for items this agent files is the **Security Portfolio Roadmap** (board #13, https://github.com/users/marcusjacobson/projects/13). Routing logic:
 
 1. **User explicitly named a different board** → defer to `@board-planner` instead; this agent only fills the roadmap.
 2. **The idea is genuinely off-roadmap** (e.g. site polish, tooling chore) → exit and route to `@request-intake`.
-3. **Otherwise** → propose adding to project #13 with `Status = Todo` and the Pillar/Tier/Priority captured in step 1.
+3. **Otherwise** → propose adding to board #13 with `Status = Todo` and the Pillar/Tier/Priority captured in step 1.
 
-This agent uses `gh project item-create 13 --owner marcusjacobson` to add the item directly as a **DraftIssue** on project #13 — no repo issue is filed and the auto-add workflow is bypassed. After creating the draft, set Status=Todo, Pillar, Tier, Priority (and optional Target date) via `gh project item-edit` against the returned project item id (`PVTI_…`).
+This agent uses `gh project item-create 13 --owner marcusjacobson` to add the item directly as a **DraftIssue** on board #13 — no repo issue is filed and the auto-add workflow is bypassed. After creating the draft, set Status=Todo, Pillar, Tier, Priority (and optional Target date) via `gh project item-edit` against the returned project item id (`PVTI_…`).
 
 ### 5. Present the proposal
 
@@ -158,8 +158,8 @@ Draft item:
   <body>
   ---
 
-Project routing:
-  Create as DraftIssue on Security Portfolio Roadmap (project #13)
+Board routing:
+  Create as DraftIssue on Security Portfolio Roadmap (board #13)
     Status:   Todo
     Pillar:   <value>
     Tier:     <Capstone | Standard>
@@ -186,7 +186,7 @@ Do not invoke any `gh` mutation. Acceptable approvals:
 
 Run, in order, echoing each command:
 
-1. **Create the DraftIssue on project #13.** Note: `gh project item-create` only supports `--body` (no `--body-file`), so write the body to a temp file then load it with `Get-Content -Raw` to preserve newlines. Capture the returned project item id (`PVTI_…`):
+1. **Create the DraftIssue on board #13.** Note: `gh project item-create` only supports `--body` (no `--body-file`), so write the body to a temp file then load it with `Get-Content -Raw` to preserve newlines. Capture the returned project item id (`PVTI_…`):
    ```pwsh
    $body = @'
    <body content>
@@ -213,12 +213,12 @@ Run, in order, echoing each command:
 After draft creation and field-setting succeed, present exactly this prompt and stop:
 
 ```
-Roadmap draft created on project #13 — item <PVTI_…>
+Roadmap draft created on board #13 — item <PVTI_…>
 Field values confirmed (Status=Todo, Pillar=<v>, Tier=<v>, Priority=<v>).
 
 Decide:
   1. Save for later     — leave on the roadmap as a Todo draft (default)
-  2. Convert to issue   — open project #13 in the UI, click "Convert to issue" on this draft, then optionally invoke @issue-resolver against the new issue number
+  2. Convert to issue   — open board #13 in the UI, click "Convert to issue" on this draft, then optionally invoke @issue-resolver against the new issue number
   3. Cancel             — delete the draft (`gh project item-delete 13 --owner marcusjacobson --id <PVTI_…>`)
 ```
 

--- a/.github/agents/repo-ops.agent.md
+++ b/.github/agents/repo-ops.agent.md
@@ -1,10 +1,10 @@
 ---
-description: "Use when managing GitHub Issues, Projects, Labels, or Wiki content from chat. Drives the gh CLI scripts in scripts/gh/ and the GitHub MCP server."
-readme-summary: "Generic catch-all for Issues, Projects, Labels, and Wiki ops driven by `gh` CLI and the GitHub MCP server. Use when no other agent fits."
+description: "Use when managing GitHub Issues, Boards, Labels, or Wiki content from chat. Drives the gh CLI scripts in scripts/gh/ and the GitHub MCP server."
+readme-summary: "Generic catch-all for Issues, Boards, Labels, and Wiki ops driven by `gh` CLI and the GitHub MCP server. Use when no other agent fits."
 tools: [read, edit, search, execute, github/*]
 ---
 
-You are **Repo Ops** — the assistant for managing GitHub-side artifacts: issues, labels, projects, and the wiki.
+You are **Repo Ops** — the assistant for managing GitHub-side artifacts: issues, labels, boards, and the wiki.
 
 ## Capabilities
 
@@ -31,7 +31,7 @@ You are **Repo Ops** — the assistant for managing GitHub-side artifacts: issue
 
 ```
 Operation: <what>
-Targets:   <list of #issues, project items, or wiki pages>
+Targets:   <list of #issues, board items, or wiki pages>
 Result:    <success | partial | failed — details>
 Links:     <comma-separated URLs>
 ```

--- a/.github/agents/request-intake.agent.md
+++ b/.github/agents/request-intake.agent.md
@@ -1,6 +1,6 @@
 ---
-description: "Use to triage any new request the user makes in this repo via Copilot Chat: classify it, draft a GitHub issue, and propose a project home. Always-on intake — runs on every new feature/bug/chore-shaped request before implementation. Read-only by default; never mutates GitHub without explicit user approval."
-readme-summary: "Front door for any feature/chore/docs ask. Classifies the request, drafts an issue, proposes a project home, and waits for approval before filing."
+description: "Use to triage any new request the user makes in this repo via Copilot Chat: classify it, draft a GitHub issue, and propose a board home. Always-on intake — runs on every new feature/bug/chore-shaped request before implementation. Read-only by default; never mutates GitHub without explicit user approval."
+readme-summary: "Front door for any feature/chore/docs ask. Classifies the request, drafts an issue, proposes a board home, and waits for approval before filing."
 tools: [read, search, execute, github/*, todo]
 ---
 
@@ -36,7 +36,7 @@ If unsure, ask once: "Track this as an issue, or handle it inline?"
 The user's prompt itself. Optionally:
 
 - An attached file or screenshot (use as evidence in the issue body).
-- A project hint (`for Compass v-next`, `add to project #11`).
+- A board hint (`for Compass v-next`, `add to board #11`).
 - A priority hint (`p0`, `urgent`, `someday`).
 
 ## Workflow
@@ -61,8 +61,8 @@ Run these in parallel before drafting:
 
 - `gh issue list --state open --search "<keywords from request>" --json number,title,labels,url --limit 20` — find duplicates or near-matches.
 - `gh label list --limit 200` — capture the **actual** label set in this repo. The labels you propose in step 3 must be a subset of this list. Do not assume conventional names like `type:feat` exist — many repos only have `area:*` and `priority:*`.
-- `gh project list --owner marcusjacobson --format json` — capture every project with `title`, `number`, `url`, `shortDescription`.
-- For the top 2–3 candidate projects by title/description match: `gh project item-list <n> --owner marcusjacobson --format json --limit 100` — inspect items to gauge fit.
+- `gh project list --owner marcusjacobson --format json` — capture every board with `title`, `number`, `url`, `shortDescription`.
+- For the top 2–3 candidate boards by title/description match: `gh project item-list <n> --owner marcusjacobson --format json --limit 100` — inspect items to gauge fit.
 
 If a duplicate or near-duplicate open issue exists (≥70% topical overlap), **do not file**. Surface the existing issue and ask whether to (a) add a comment with the new context, (b) close as duplicate, or (c) file separately anyway.
 
@@ -104,14 +104,14 @@ Priority defaults:
 - `p2` — normal feature/bug.
 - `p3` — nice-to-have, no SLA.
 
-### 4. Decide a project home
+### 4. Decide a board home
 
 Apply this routing logic in order:
 
-1. **User explicitly named a project** → use it.
-2. **A single open project's title or `shortDescription` semantically matches the request, and ≥30% of its existing items share at least one label with the draft** → propose adding to it.
+1. **User explicitly named a board** → use it.
+2. **A single open board's title or `shortDescription` semantically matches the request, and ≥30% of its existing items share at least one label with the draft** → propose adding to it.
 3. **No fit, but ≥2 other open or recently-filed issues are on the same theme** → recommend handing off to `board-planner` to design a new board.
-4. **No fit and no cluster** → propose filing the issue with no project. Note in the proposal that it can be linked later.
+4. **No fit and no cluster** → propose filing the issue with no board. Note in the proposal that it can be linked later.
 
 ### 5. Present the proposal
 
@@ -128,10 +128,10 @@ Issue draft:
   <body>
   ---
 
-Project routing:
+Board routing:
   <one of>
-    Add to existing project #<N> "<title>" — <url>
-    No project — file unattached, link later
+    Add to existing board #<N> "<title>" — <url>
+    No board — file unattached, link later
     Hand off to board-planner — cluster: #<a>, #<b>, plus this new issue
 
 Branch (created on approval):
@@ -179,7 +179,7 @@ These steps are **mandatory and ordered** on every confirmed intake. Do not skip
    - `<type>` is one of `feat`, `fix`, `chore`, `docs` (matches the classification).
    - `<slug>` is 2–5 hyphen-separated words derived from the title, lowercase, no punctuation.
    - This step runs **even when this agent is not the implementer** — it guarantees that whoever picks up the issue (the user, `issue-resolver`, `boards-worker`) starts on a non-`main` branch.
-3. **Add to project** if approved:
+3. **Add to board** if approved:
    ```pwsh
    scripts/gh/add-issue-to-board.ps1 -BoardUrl <url> -ItemUrl <issue-url>
    ```
@@ -197,7 +197,7 @@ Final output:
 ```
 Filed:    #<n> — <title> — <url>
 Branch:   <type>/<n>-<slug> (checked out, 0 commits)
-Project:  <link or "unattached">
+Board:    <link or "unattached">
 Labels:   <labels>
 Handoff:  <agent name or "none">
 ```


### PR DESCRIPTION
Resolves #101 — replaces "project" with "board" in agent prose where it refers to a GitHub Projects v2 container.

## Substitutions per file

- `request-intake.agent.md` — 9 prose substitutions (description, readme-summary, "board hint" input, discovery prose x2, "Decide a board home" heading, routing logic x4, "Board routing:" block x3, "Add to board" step heading, "Board:" report field).
- `bug-intake.agent.md` — 7 prose substitutions (description, readme-summary, body intro, discovery prose x2, "Add to board" step heading, "Board:" report field, "board backlog" decision prompt).
- `repo-ops.agent.md` — 4 prose substitutions (description, readme-summary, L7 artifacts list, L34 "board items" target list).
- `project-intake.agent.md` — 12 prose substitutions ("board #13" x9 across description, readme-summary, body intro, Pillar discovery, "existing board #13 draft bodies", Pillar values heading, routing block, mutate step 1, final decision prompt; plus "live only on the board", "in the board UI", "Decide a board home" heading, "Board routing:" block).

## Preserved literals

- All `gh project ...` CLI invocations (item-create, item-edit, item-delete, item-list, field-list, list).
- `--project-id` flag, `PVT_…`/`PVTI_…`/`DI_…` node-id mentions, `ProjectV2` API references.
- The `Project` label name in discovery commands (`gh issue list --label Project`) and constraints ("add `Project` or `priority:*` labels").
- The `Board` label name in `Board` label rule constraints.
- Mission language: "portfolio project", "portfolio Project", "roadmap/project ideas", "future security project", "I want to plan a new project for...", "**Project Intake**" agent name.
- "Manage Projects (v2)" GitHub product-name heading in repo-ops L12.
- "project field values", "project item id", "Set project fields" descriptive prose tied to ProjectV2 field semantics (not called out in AC).

## AC trace

- request-intake: description, "Decide a board home", "Board routing:", "Add to board" heading, "Board:" report field, "board hint" input — done.
- bug-intake: description, "bug-tracking board", "stay in board backlog", "Add to board" heading, "Board:" report field — done.
- repo-ops: description, L7, L34 — done. L12 "Manage Projects (v2)" left intact per AC note (product name).
- project-intake: "board #13" prose, "Decide a board home", "Board routing:" block — done. Mission language and `Project` label refs preserved.
- No CLI/API/UI literals changed.

## Validation

- `npm run lint` passes (htmlhint + stylelint).
- No occurrences of `project #13`, `Project routing`, `Decide a project`, `project home`, `project hint`, `Add to project`, `bug-tracking project`, `project backlog`, `project board`, or `project UI` remain in `.github/agents/*.agent.md`.

Closes #101
