### PR TITLE
Add @maturity-scout agent and weekly scan workflow

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -16,6 +16,7 @@ Specialized chat agents (`*.agent.md`) you can summon in Copilot Chat with `@<ag
 | [`@publish-manager`](publish-manager.agent.md) | Orchestrates a portfolio publish: local validation, branch, commit, push, PR, and check-watching. | Yes |
 | [`@security-reviewer`](security-reviewer.agent.md) | Reviews a PR diff for XSS, secret leakage, supply-chain risk, unsafe workflow permissions, and CDN trust. | Read-only |
 | [`@repo-ops`](repo-ops.agent.md) | Generic catch-all for Issues, Projects, Labels, and Wiki ops driven by `gh` CLI and the GitHub MCP server. Use when no other agent fits. | Yes |
+| [`@maturity-scout`](maturity-scout.agent.md) | Scans the repo against Microsoft Learn, GitHub docs, OWASP, WCAG, and repo-hygiene best practices and surfaces gap issues onto the Portfolio Maturity board (#15). On-demand mode is read-only; the weekly workflow auto-files candidates with `needs-triage`. | Read-only until approval (chat); auto-files (weekly workflow) |
 <!-- END: agents-index -->
 
 ## How they fit together

--- a/.github/agents/maturity-scout.agent.md
+++ b/.github/agents/maturity-scout.agent.md
@@ -1,0 +1,233 @@
+---
+description: "Use to audit this repo against Microsoft Learn, GitHub docs, OWASP, WCAG, and repo-hygiene best practices and surface improvement issues onto the Portfolio Maturity board (#15). Read-only by default; never mutates GitHub without explicit user approval. Also defines the contract for the weekly maturity-scan workflow."
+readme-summary: "Scans the repo against Microsoft Learn, GitHub docs, OWASP, WCAG, and repo-hygiene best practices and surfaces gap issues onto the Portfolio Maturity board (#15). On-demand mode is read-only; the weekly workflow auto-files candidates with `needs-triage`."
+tools: [read, search, execute, github/*, todo]
+---
+
+You are **Maturity Scout** — an audit agent that compares this repo and the live portfolio against current external best-practice sources, then surfaces tracked work for any gap. You never ship code yourself; you hand off to `@issue-resolver` or `@boards-worker` after items are filed.
+
+You operate in two modes:
+
+- **On-demand** — invoked from Copilot Chat. Read-only by default; mutates only on explicit same-turn approval (same contract as `@request-intake` and `@board-planner`).
+- **Weekly automation** — driven by `.github/workflows/maturity-scan.yml`. The workflow files candidate issues directly with the `needs-triage` label so the user can sweep them later from chat. The workflow follows the same filed-issue shape and dedupe rules defined here.
+
+## When to engage
+
+Engage when the user asks any of:
+
+- "Run a maturity scan."
+- "What am I missing against MS Learn / GitHub docs / OWASP / WCAG?"
+- "Audit the repo for best-practice gaps."
+- "Refresh the Portfolio Maturity board."
+- "Show me the weekly scan results."
+
+Do **not** engage — answer directly or hand off — when:
+
+- The user asks a single targeted question about a specific best practice (answer directly, no issue needed).
+- The user wants to implement a specific known gap (use `@request-intake` or `@issue-resolver` instead).
+- The user wants to create or restructure a board (use `@board-planner`).
+
+## Inputs
+
+- Optional source filter (`source:ms-learn`, `source:github-docs`, `source:owasp`, `source:wcag`, `source:repo-hygiene`). Default: all five.
+- Optional target area (`area:html`, `area:workflow`, `area:wiki`, `area:docs`). Default: all areas.
+- Optional `--max=<N>` cap on candidate count per run. Default: 10.
+
+## Sources in scope
+
+| Source label | Scope |
+|---|---|
+| `source:ms-learn` | Microsoft Learn pages for Defender for Cloud, Entra ID, Sentinel, Purview, Azure security baselines, and any Microsoft technology actively claimed on the live portfolio (`ms_security_*.html`, `skills_inventory.html`, `certification_strategy.html`). |
+| `source:github-docs` | GitHub docs for Actions hardening, Pages, Projects v2, branch protection, CodeQL, gitleaks, dependency review, secret scanning, repo settings. |
+| `source:owasp` | OWASP Top 10 and ASVS controls applicable to a static HTML site (XSS, CSP, SRI, link target hardening, mixed content). |
+| `source:wcag` | WCAG 2.2 AA success criteria for the live portfolio pages. |
+| `source:repo-hygiene` | GitHub-recommended repo metadata (`CODEOWNERS`, `SECURITY.md`, `CONTRIBUTING.md`, `FUNDING.yml`), dependency review, license file, README badges, issue/PR templates, branch-protection completeness. |
+
+## Workflow (on-demand mode)
+
+### 1. Prepare
+
+Run the following discovery commands in parallel and capture results:
+
+```pwsh
+gh issue list --state all --search "in:title in:body label:source:ms-learn,source:github-docs,source:owasp,source:wcag,source:repo-hygiene" --json number,title,labels,state,url,closedAt --limit 200
+gh project item-list 15 --owner marcusjacobson --format json --limit 200
+gh label list --limit 200 --json name
+```
+
+The first call captures every issue ever filed with a `source:*` label (open + closed).
+The second captures every item on the Portfolio Maturity board (open + closed).
+The third confirms the live label set so you never propose a label that does not exist.
+
+### 2. Audit
+
+For each enabled source, identify gaps by comparing the live repo against the source's recommendations. Use:
+
+- File reads inside the workspace (no network needed for repo-hygiene checks).
+- `fetch_webpage` for current best-practice content from Microsoft Learn and GitHub docs.
+- The OWASP and WCAG checklists embedded in `wiki/Maturity-Scout.md` for static-site checks.
+
+Per gap, capture:
+
+- A short identifying phrase (used for dedupe).
+- The source URL and a 1–2 sentence excerpt.
+- The specific repo path or live-page selector affected.
+- A one-line suggested change.
+
+### 3. Dedupe
+
+For each candidate gap, refuse to propose if any of the following match the existing-issues set from step 1 OR the board-items set:
+
+- An open issue with ≥70% topical overlap on title + body keywords.
+- A closed-as-completed issue (`stateReason: COMPLETED`) within the last 90 days with ≥70% overlap.
+- A board item (open or closed) on board #15 with ≥70% overlap.
+
+Topical overlap is judged by:
+
+1. Same source label.
+2. Title or body shares ≥3 distinguishing keywords (not stop-words, not "Azure" / "GitHub" alone).
+3. Same affected file or page.
+
+When a candidate is suppressed, log the reason and the matched issue/item URL in the proposal block under a `Suppressed (dedupe)` section so the user can override if needed.
+
+### 4. Draft
+
+For each surviving candidate produce this block — do not file yet:
+
+```text
+Title: <imperative, ≤72 chars>
+
+Labels: needs-triage, source:<one>, Board, <optional area:*>
+
+Body:
+## Source
+<URL>
+
+> <1–2 sentence excerpt>
+
+## Why it matters
+<plain-language statement of the gap and risk/benefit>
+
+## Suggested change
+<one paragraph or short bullet list naming the file or page to change>
+
+## Acceptance criteria
+- [ ] <AC1>
+- [ ] <AC2>
+- [ ] <AC3 if needed>
+
+Project field defaults: Status=Backlog, Priority=p2, Source=<MS Learn|GitHub Docs|OWASP|WCAG|Repo Hygiene>.
+```
+
+### 5. Present
+
+Output exactly one proposal block. No prose framing.
+
+```text
+Maturity scan — <YYYY-MM-DD> — sources: <list> — areas: <list> — max: <N>
+
+Discovered: <total candidates>
+Suppressed (dedupe): <count>
+  - <title> — overlaps with #<n> "<title>" (link)
+  - ...
+
+Proposed (<count>):
+
+[1] <title>
+    Labels: <labels>
+    Body: (rendered below)
+    ---
+    <body>
+    ---
+
+[2] <title>
+    ...
+
+Board placement: All items → Portfolio Maturity (#15), Status=Backlog, Priority=p2, Source=<value>.
+
+Reply: file all | file 1,3,5 | edit <n>: <changes> | cancel
+```
+
+### 6. Wait for explicit approval
+
+Acceptable approvals:
+
+- `file all` — file every proposed item in order.
+- `file <N>` or `file <N>,<M>,...` — file only the named items.
+- `edit <N>: <changes>` — apply changes to item N, re-print the proposal, re-ask.
+- `cancel` — drop everything, ack, exit.
+
+Never invoke a `gh` mutation without one of the above on the same turn.
+
+### 7. Mutate (only after approval)
+
+For each approved candidate, in order:
+
+1. **Create the issue** using the pwsh body-file pattern:
+
+   ```pwsh
+   $body = @'
+   <body content>
+   '@
+   $tmp = New-TemporaryFile
+   $body | Set-Content $tmp -Encoding UTF8
+   gh issue create --title "<title>" --label "<labels>" --body-file $tmp
+   Remove-Item $tmp
+   ```
+
+   Capture the returned issue number and URL.
+
+2. **Attach to board #15** via the existing helper:
+
+   ```pwsh
+   scripts/gh/add-issue-to-board.ps1 -BoardUrl "https://github.com/users/marcusjacobson/projects/15" -ItemUrl <issue-url>
+   ```
+
+3. **Set the `Source` field** on the project item to the matching value via `gh project item-edit`. Capture field IDs once at the start of the mutation phase using `gh project field-list 15 --owner marcusjacobson --format json` and reuse them for every item in this run.
+
+4. **Do not create branches.** Implementation is left to `@issue-resolver` or `@boards-worker`.
+
+### 8. Report
+
+Final output:
+
+```text
+Filed: <count>
+  #<n> — <title> — <url>
+  ...
+Board: Portfolio Maturity (#15) — all items added, Source field set
+Suppressed (dedupe): <count>
+Handoff: none — invoke @boards-worker on board #15 when ready to drain
+```
+
+## Workflow (weekly automation mode)
+
+The `.github/workflows/maturity-scan.yml` workflow is the unattended counterpart. It runs on `workflow_dispatch` and a weekly cron. The workflow:
+
+1. Checks out the repo (no network secrets needed for repo-hygiene checks).
+2. Runs the same audit step as on-demand mode, restricted to deterministic checks that don't require LLM judgment (initial scope: `source:repo-hygiene` only — file existence checks for `CODEOWNERS`, `SECURITY.md`, `CONTRIBUTING.md`, `LICENSE`, `dependabot.yml`, `.github/ISSUE_TEMPLATE/`, etc.).
+3. Performs the same dedupe pass against open issues and board items via `gh`.
+4. Files each surviving candidate as an issue with `needs-triage`, the appropriate `source:*` label, `Board`, and any applicable `area:*` label.
+5. Relies on `.github/workflows/board-autoadd.yml` to attach the new `Board`-labeled issue to the appropriate board. Because that workflow targets board #13, the scan workflow attaches to board #15 directly via `actions/add-to-project`.
+6. Posts a summary to the workflow run log: `Filed: <n>; Suppressed: <m>`.
+
+The workflow does **not** run network-dependent source checks (Microsoft Learn, GitHub docs, OWASP, WCAG) on the unattended schedule. Those require LLM judgment for relevance and dedupe and stay in on-demand mode. The weekly run is intentionally narrow and high-precision.
+
+## Hard rules
+
+- **Read-only by default.** No `gh issue create`, no `gh project item-add`, no label mutation in on-demand mode without explicit user approval in the same turn the proposal was presented.
+- **One scan per invocation.** Do not chain a second scan onto the same approval.
+- **No code edits.** This agent never modifies repository files. Implementation is always handed off.
+- **Never invent labels.** Source labels must be one of the five `source:*` values. Area labels must already exist in `gh label list` output. If the right label is missing, recommend adding it via `@repo-ops` rather than improvising.
+- **Cap candidates.** Default `--max=10` per run. The user can raise it; the weekly workflow defaults to 5.
+- **Dedupe is mandatory.** Any candidate with ≥70% overlap against an existing item is suppressed and reported, never silently filed.
+- **Issue-first contract still applies.** Every filed issue must follow the four-section body shape (Source, Why it matters, Suggested change, Acceptance criteria). Issues missing any section are a contract violation.
+- **No `--admin`, no force, no shortcuts.** This agent only files issues and attaches them to the board. It never edits code, never closes issues, never modifies labels on existing issues.
+
+## Output discipline
+
+- No emoji.
+- No prose framing around the proposal block.
+- Always echo `gh` commands before running them.
+- Never claim to have filed something you have not filed.
+- The summary report after mutation lists every filed issue by `#<n> — <title> — <url>` so the user can copy-paste into a comment if needed.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -44,6 +44,23 @@
 - name: priority:p3
   color: 0e8a16
 
+# Source (used by @maturity-scout to tag the origin of a recommendation)
+- name: source:ms-learn
+  color: 0078d4
+  description: Recommendation sourced from Microsoft Learn.
+- name: source:github-docs
+  color: 24292e
+  description: Recommendation sourced from GitHub documentation.
+- name: source:owasp
+  color: 7a1818
+  description: Recommendation sourced from OWASP (Top 10 / ASVS).
+- name: source:wcag
+  color: 1d76db
+  description: Recommendation sourced from WCAG 2.2 accessibility guidelines.
+- name: source:repo-hygiene
+  color: 5319e7
+  description: General repo hygiene best practice (CODEOWNERS, SECURITY.md, dependency review, etc).
+
 # Lifecycle
 - name: needs-triage
   color: fef2c0

--- a/.github/workflows/maturity-scan.yml
+++ b/.github/workflows/maturity-scan.yml
@@ -1,0 +1,190 @@
+name: Maturity Scout (weekly scan)
+
+on:
+  workflow_dispatch:
+    inputs:
+      max:
+        description: "Max candidate issues to file in this run"
+        required: false
+        default: "5"
+  schedule:
+    # 14:00 UTC every Monday — outside business hours but visible in morning sweeps.
+    - cron: "0 14 * * 1"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: maturity-scan
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    name: Repo-hygiene maturity scan
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      MAX_FILED: ${{ github.event.inputs.max || '5' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Network egress assumptions: this job intentionally performs NO live
+      # fetches against Microsoft Learn, GitHub docs, OWASP, or WCAG. Source
+      # checks that need LLM judgment stay in the on-demand chat mode of
+      # @maturity-scout. The unattended job only runs deterministic
+      # repo-hygiene checks (file existence in this checkout) plus dedupe
+      # queries against the GitHub API.
+
+      - name: Run repo-hygiene checks and file gap issues
+        id: scan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          REPO="${GITHUB_REPOSITORY}"
+          BOARD_URL="https://github.com/users/marcusjacobson/projects/15"
+          MAX="${MAX_FILED}"
+
+          # ---- Define checks: each entry is "key|path|title|body".
+          # Bodies follow the four-section shape required by issue #110 AC5.
+          declare -a CHECKS=()
+
+          add_check () {
+            CHECKS+=("$1")
+          }
+
+          read_body () {
+            cat <<EOF
+## Source
+
+GitHub repository community standards — <https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions>
+
+> GitHub recommends a baseline of community health files (\`$2\`) so contributors and consumers know what to expect.
+
+## Why it matters
+
+The portfolio repo is public. Missing \`$2\` weakens the contributor and reviewer signal and lowers the GitHub community-profile score, which is one of the visible maturity indicators on the public repo page.
+
+## Suggested change
+
+Add \`$2\` at the documented location with portfolio-appropriate content. Keep it minimal but real — no placeholder text.
+
+## Acceptance criteria
+
+- [ ] \`$2\` exists at the canonical path.
+- [ ] Content is reviewed (not template boilerplate).
+- [ ] Wiki / README cross-links updated if applicable.
+EOF
+          }
+
+          # path | title-suffix | label-area
+          declare -a TARGETS=(
+            "SECURITY.md|Add SECURITY.md so vulnerability reporting has a documented channel|area:docs"
+            "CONTRIBUTING.md|Add CONTRIBUTING.md to document the intake + branch + PR workflow|area:docs"
+            "CODEOWNERS|Add CODEOWNERS so reviews route automatically|area:workflow"
+            ".github/ISSUE_TEMPLATE|Add issue templates so community filings match the four-section shape|area:workflow"
+            ".github/PULL_REQUEST_TEMPLATE.md|Add a pull-request template aligned to the repo conventions|area:workflow"
+            ".github/dependabot.yml|Enable Dependabot for Actions and any tracked manifests|area:workflow"
+            "LICENSE|Add a LICENSE file so the portfolio's reuse terms are explicit|area:docs"
+          )
+
+          # ---- Pull existing issues + board items for dedupe.
+          echo "::group::Fetch existing issues with source:* labels"
+          EXISTING_ISSUES=$(gh issue list \
+            --state all \
+            --search 'in:title in:body label:source:repo-hygiene' \
+            --json number,title,state,closedAt,url \
+            --limit 200)
+          echo "$EXISTING_ISSUES" | jq 'length as $n | "found \($n) issues"'
+          echo "::endgroup::"
+
+          echo "::group::Fetch board #15 items"
+          BOARD_ITEMS=$(gh project item-list 15 \
+            --owner marcusjacobson \
+            --format json \
+            --limit 200 || echo '{"items":[]}')
+          echo "$BOARD_ITEMS" | jq '.items | length as $n | "found \($n) board items"'
+          echo "::endgroup::"
+
+          FILED=0
+          SUPPRESSED=0
+          SUMMARY_FILED=""
+          SUMMARY_SUPPRESSED=""
+
+          for entry in "${TARGETS[@]}"; do
+            if [[ "$FILED" -ge "$MAX" ]]; then
+              echo "Hit max ($MAX); stopping."
+              break
+            fi
+
+            IFS='|' read -r CHECK_PATH TITLE AREA <<< "$entry"
+
+            # Skip if the file/dir already exists in the checkout — no gap.
+            if [[ -e "$CHECK_PATH" ]]; then
+              echo "Present: $CHECK_PATH — skipping."
+              continue
+            fi
+
+            # Dedupe: open or recently-closed (90d) issue mentioning this path?
+            MATCH=$(echo "$EXISTING_ISSUES" | jq -r --arg p "$CHECK_PATH" \
+              '[.[] | select(.title | test($p; "i"))] | .[0] // empty | "\(.number)|\(.url)|\(.state)"')
+            if [[ -n "$MATCH" ]]; then
+              SUPPRESSED=$((SUPPRESSED+1))
+              SUMMARY_SUPPRESSED+=$'\n  - '"$CHECK_PATH"' — overlaps with '"$MATCH"
+              echo "Dedup suppressed: $CHECK_PATH overlaps $MATCH"
+              continue
+            fi
+
+            # Dedupe: board item with same path in title?
+            BMATCH=$(echo "$BOARD_ITEMS" | jq -r --arg p "$CHECK_PATH" \
+              '.items[]? | select(.title // "" | test($p; "i")) | .id' | head -n1)
+            if [[ -n "$BMATCH" ]]; then
+              SUPPRESSED=$((SUPPRESSED+1))
+              SUMMARY_SUPPRESSED+=$'\n  - '"$CHECK_PATH"' — overlaps with board item '"$BMATCH"
+              echo "Board-dedup suppressed: $CHECK_PATH overlaps $BMATCH"
+              continue
+            fi
+
+            # Build body and file the issue.
+            BODY=$(read_body "$TITLE" "$CHECK_PATH")
+            BODY_FILE=$(mktemp)
+            printf '%s\n' "$BODY" > "$BODY_FILE"
+
+            echo "Filing: $TITLE"
+            URL=$(gh issue create \
+              --title "$TITLE" \
+              --label "needs-triage,source:repo-hygiene,$AREA" \
+              --body-file "$BODY_FILE")
+            rm -f "$BODY_FILE"
+
+            FILED=$((FILED+1))
+            SUMMARY_FILED+=$'\n  - '"$URL"' — '"$TITLE"
+
+            # Board attach happens in the next step via actions/add-to-project,
+            # filtered on the `source:repo-hygiene` label this step just applied.
+          done
+
+          {
+            echo "## Maturity Scout — weekly scan"
+            echo ""
+            echo "Filed: $FILED"
+            if [[ -n "$SUMMARY_FILED" ]]; then echo "$SUMMARY_FILED"; fi
+            echo ""
+            echo "Suppressed (dedupe): $SUPPRESSED"
+            if [[ -n "$SUMMARY_SUPPRESSED" ]]; then echo "$SUMMARY_SUPPRESSED"; fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Attach filed issues to Portfolio Maturity board (#15)
+        if: always()
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        with:
+          project-url: https://github.com/users/marcusjacobson/projects/15
+          # BUG_PROJECT_TOKEN is the shared classic PAT with `project` scope
+          # documented in repo memory. It can attach issues to user-owned
+          # Projects v2 boards but cannot mutate labels — so the scan step
+          # above applies labels with the default GITHUB_TOKEN, then this
+          # step uses the PAT to attach.
+          github-token: ${{ secrets.BUG_PROJECT_TOKEN }}
+          labeled: source:repo-hygiene

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -16,12 +16,32 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 | [11](https://github.com/users/marcusjacobson/projects/11) | Cloud Agent Enablement | One-shot deliverable to enable the GitHub-hosted Copilot cloud agent (Agents tab + `@copilot` assignment): `AGENTS.md`, `copilot-setup-steps.yml`, `agent-task` template, MCP allow-list, smoke test, docs. Issues #32–#40. Schema adds **Source** (config / docs / smoke-test). Complementary to board #10 via Option B manual handoff: LinkedIn-Sync emits gap issues in the `agent-task` template; humans triage and assign `@copilot`. |
 | [12](https://github.com/users/marcusjacobson/projects/12) | Bug Tracker | Rolling backlog for every issue tagged `bug`. Schema adds **Priority** (p0–p3), **Severity** (Critical/Major/Minor/Trivial), **Area** (html/css/docs/wiki/workflow), **Reported** (date). Status: Backlog → Triaged → In progress → In review → Done. Auto-seeded by the `Bug auto-add to project` workflow (`.github/workflows/bug-autoadd.yml`); the `@bug-intake` agent files the issue with the `bug` label and the workflow adds it to board #12. First item: #57 (tagline width). |
 | [13](https://github.com/users/marcusjacobson/projects/13) | Microsoft Security Portfolio Roadmap | Rolling roadmap for the 16 forward-looking labs and capstones described in `staging-inbox/ms_security_projects_roadmap_v1.html`. Schema adds **Priority** (p0–p3), **Pillar** (Capstone / Cross-pillar / Purview / Defender + Sentinel / Entra / Azure / Security Copilot), **Tier** (Capstone / Standard), **Target date**. Hybrid item strategy: 3 Active items as tracking issues (#73, #74, #75) so they show up in repo issue search; 5 capstones + 10 standard Planned items as draft items (work lives in dedicated repos, not here). |
+| [15](https://github.com/users/marcusjacobson/projects/15) | Portfolio Maturity | Rolling backlog for repo + live-portfolio improvements surfaced against external best-practice sources (Microsoft Learn, GitHub Docs, OWASP, WCAG, repo hygiene). Schema adds **Priority** (p0–p3), **Size** (XS/S/M/L), **Source** (MS Learn / GitHub Docs / OWASP / WCAG / Repo Hygiene / Other), **Target date**. Status: Backlog → Ready → In progress → In review → Done. Seeded by the upcoming `@maturity-scout` agent (issue #110); weekly `maturity-scan.yml` workflow auto-files candidates with `needs-triage` + a `source:*` label. First item: #110 (agent build). |
 
 ## Secrets
 
 - **`BUG_PROJECT_TOKEN`** — **classic PAT** with the `project` scope (full control). Used by `.github/workflows/bug-autoadd.yml` to add issues to user-scope board #12. A classic token is required because fine-grained PATs do not currently support user-owned Projects v2 (only org-owned), and the default `GITHUB_TOKEN` cannot write Projects v2 at all. Include `repo` scope as well if the repo ever goes private. Rotate every 12 months or sooner; if expired, the workflow run errors (the issue itself shows no symptom). Repository secret name: `BUG_PROJECT_TOKEN` (name retained for back-compat — do not rename).
 
 ## Sweep log
+
+### 2026-04-26 — create Portfolio Maturity board (#15)
+
+Inputs: user request via `@request-intake` → `@board-planner` — "create an agent that scans the repo on demand or weekly and adds issues to a board for areas I can mature the repo or live portfolio based on Microsoft Learn, GitHub docs, and other well-known best practices; dedupe against existing recommendations." Board needed up front so the agent-build issue and all future scanner output land in one place.
+
+Decisions:
+
+- **New board #15 "Portfolio Maturity"** — rolling backlog. Threshold met because the weekly scanner will continuously feed it; first explicit item is the agent-build issue (#110).
+- **Schema:** custom fields `Priority` (p0/p1/p2/p3), `Size` (XS/S/M/L), `Source` (MS Learn / GitHub Docs / OWASP / WCAG / Repo Hygiene / Other), `Target date` (date). Default `Status` field with options Backlog → Ready → In progress → In review → Done (rename of default options deferred to first triage pass).
+- **Linked to repo** — appears on the Projects tab.
+- **Label additions to `.github/labels.yml`:** `source:ms-learn`, `source:github-docs`, `source:owasp`, `source:wcag`, `source:repo-hygiene`. Synced via `scripts/gh/sync-labels.ps1`. Each scanner-filed issue gets exactly one `source:*` label plus `needs-triage` and `Board`.
+- **Seeded #110** (agent build) via `scripts/gh/add-issue-to-board.ps1`. Branch `feat/110-maturity-scout-agent` cut off latest `main` so the implementer can ship the agent file, weekly workflow, and `wiki/Maturity-Scout.md`.
+- **Follow-up (in-flight):** issue #110 implementation — `.github/agents/maturity-scout.agent.md`, `.github/workflows/maturity-scan.yml`, `wiki/Maturity-Scout.md`, and `agents/README.md` registration. Hand off to `@issue-resolver` when ready.
+
+Redundancy report (post-state):
+
+- 0 issues in two or more boards (#110 is only on #15).
+- 0 board pairs with ≥50% item overlap (board #15 is disjoint from #2, #9, #10, #11, #12, #13).
+- 0 sunset candidates.
 
 ### 2026-04-26 — boards-worker session: Board Terminology Split (#14) — continuation
 

--- a/wiki/Maturity-Scout.md
+++ b/wiki/Maturity-Scout.md
@@ -4,7 +4,7 @@
 
 The agent is read-only by default. It never files an issue, attaches to a board, or edits a label without explicit user approval in the same chat turn — same contract as every other intake-style agent in this repo.
 
-A companion weekly workflow ([`maturity-scan.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/workflows/maturity-scan.yml)) runs the deterministic subset on a schedule and files candidates with the `needs-triage` label so the user can sweep them later from chat.
+A companion weekly workflow (`.github/workflows/maturity-scan.yml`) runs the deterministic subset on a schedule and files candidates with the `needs-triage` label so the user can sweep them later from chat.
 
 ## When to use it
 
@@ -61,7 +61,7 @@ The user can override a suppression by replying `edit <n>: <changes>` and the ag
 
 ## Weekly automation contract
 
-The [`maturity-scan.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/workflows/maturity-scan.yml) workflow runs on:
+The `.github/workflows/maturity-scan.yml` workflow runs on:
 
 - `workflow_dispatch` — for manual smoke tests.
 - A weekly cron (`0 14 * * 1` — Mondays at 14:00 UTC).
@@ -92,5 +92,5 @@ Network egress: the unattended job intentionally performs no live fetches agains
 
 - [Boards](Boards.md) — audit log entry for board #15.
 - [Terminology](Terminology.md) — Project (portfolio) vs Board (Projects v2).
-- Agent file: [`.github/agents/maturity-scout.agent.md`](https://github.com/marcusjacobson/portfolio/blob/main/.github/agents/maturity-scout.agent.md).
-- Workflow: [`.github/workflows/maturity-scan.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/workflows/maturity-scan.yml).
+- Agent file: `.github/agents/maturity-scout.agent.md`.
+- Workflow: `.github/workflows/maturity-scan.yml`.

--- a/wiki/Maturity-Scout.md
+++ b/wiki/Maturity-Scout.md
@@ -1,0 +1,96 @@
+# Maturity Scout
+
+`@maturity-scout` audits this repository and the live portfolio against current external best-practice sources, then surfaces tracked work onto the **Portfolio Maturity** board (#15). It is the audit counterpart to `@request-intake`: instead of waiting for the user to notice a gap, it goes looking for them.
+
+The agent is read-only by default. It never files an issue, attaches to a board, or edits a label without explicit user approval in the same chat turn — same contract as every other intake-style agent in this repo.
+
+A companion weekly workflow ([`maturity-scan.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/workflows/maturity-scan.yml)) runs the deterministic subset on a schedule and files candidates with the `needs-triage` label so the user can sweep them later from chat.
+
+## When to use it
+
+Reach for `@maturity-scout` when you want to:
+
+- Run a one-off audit against a specific source ("scan against MS Learn", "scan repo hygiene").
+- Refresh the Portfolio Maturity board after publishing a new portfolio page or claim.
+- Sweep the latest weekly run and triage what the workflow filed.
+
+Skip it when:
+
+- You already know the gap — file the issue directly through `@request-intake` or hand it to `@issue-resolver`.
+- You want to stand up a *new* board — that's `@board-planner`.
+- You want to drain an existing board — that's `@boards-worker`.
+
+## Sources in scope
+
+| Source label | What it covers |
+|---|---|
+| `source:ms-learn` | Microsoft Learn pages for the security technologies actively claimed on the portfolio: Defender for Cloud, Entra ID, Sentinel, Purview, and the Azure security baseline. Scope tracks the live pages `ms_security_*.html`, `skills_inventory.html`, and `certification_strategy.html`. |
+| `source:github-docs` | GitHub docs for Actions hardening, Pages, Projects v2, branch protection, CodeQL, gitleaks, dependency review, secret scanning, and repo settings. |
+| `source:owasp` | OWASP Top 10 and ASVS controls applicable to a static HTML site — XSS, CSP, SRI, link-target hardening, mixed content. |
+| `source:wcag` | WCAG 2.2 AA success criteria for the live portfolio pages. |
+| `source:repo-hygiene` | GitHub-recommended community-health files, Dependabot, license, branch-protection completeness, and similar repo metadata. |
+
+The five `source:*` labels are defined in [`.github/labels.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/labels.yml) and synced via `scripts/gh/sync-labels.ps1`.
+
+## Filed-issue shape
+
+Every issue the agent (or workflow) files has exactly four sections:
+
+1. `## Source` — URL plus a 1–2 sentence excerpt.
+2. `## Why it matters` — plain-language statement of the gap and why fixing it raises the maturity bar.
+3. `## Suggested change` — short paragraph or bullet list naming the specific file or page to change.
+4. `## Acceptance criteria` — 1–3 checkbox items.
+
+Labels: `needs-triage`, exactly one `source:*` value, `Board` (chat-mode only — the workflow attaches to board #15 directly to avoid accidentally hitting board #13), and any applicable `area:*` label that already exists in `gh label list`. Project field defaults: `Status=Backlog`, `Priority=p2`, `Source=<MS Learn|GitHub Docs|OWASP|WCAG|Repo Hygiene>`.
+
+## Dedupe rules
+
+A candidate is suppressed (and reported under `Suppressed (dedupe)`) when any of the following matches an existing item:
+
+- Open issue with ≥70% topical overlap on title + body keywords.
+- Issue closed as completed within the last 90 days with ≥70% overlap.
+- Any item (open or closed) on the Portfolio Maturity board (#15) with ≥70% overlap.
+
+Topical overlap requires:
+
+1. Same `source:*` label.
+2. ≥3 distinguishing keywords match (no stop-words; "Azure" and "GitHub" alone don't count).
+3. Same affected file or page.
+
+The user can override a suppression by replying `edit <n>: <changes>` and the agent will re-print and re-ask.
+
+## Weekly automation contract
+
+The [`maturity-scan.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/workflows/maturity-scan.yml) workflow runs on:
+
+- `workflow_dispatch` — for manual smoke tests.
+- A weekly cron (`0 14 * * 1` — Mondays at 14:00 UTC).
+
+What it does:
+
+- Scope is restricted to `source:repo-hygiene`. The other sources require LLM judgment for relevance and dedupe and stay in on-demand chat mode.
+- Runs deterministic file-existence checks against the checkout (no live external fetches).
+- Performs the same dedupe pass against open issues and board items via `gh`.
+- Files each surviving candidate with `needs-triage`, `source:repo-hygiene`, and the matching `area:*` label.
+- Uses `actions/add-to-project` (pinned by SHA) with the shared `BUG_PROJECT_TOKEN` classic PAT to attach to board #15. The default `GITHUB_TOKEN` cannot write Projects v2; the PAT scope-split is documented in the repo's stored agent memory.
+- Caps filings at `max` per run (default 5 for the cron, overridable via `workflow_dispatch` input).
+- Posts a `Filed: <n>; Suppressed: <m>` summary to the workflow run log.
+
+Network egress: the unattended job intentionally performs no live fetches against Microsoft Learn, GitHub docs, OWASP, or WCAG. If that scope expands later, add a separate workflow with explicit egress allow-listing rather than widening this one.
+
+## Hard rules (mirrors the agent file)
+
+- Read-only by default. No mutations without same-turn approval.
+- One scan per invocation.
+- No code edits — implementation hand-off goes to `@issue-resolver` or `@boards-worker`.
+- Never invent labels.
+- Default cap of 10 candidates per chat run, 5 per weekly cron.
+- Dedupe is mandatory.
+- Filed issues must have all four body sections.
+
+## See also
+
+- [Boards](Boards.md) — audit log entry for board #15.
+- [Terminology](Terminology.md) — Project (portfolio) vs Board (Projects v2).
+- Agent file: [`.github/agents/maturity-scout.agent.md`](https://github.com/marcusjacobson/portfolio/blob/main/.github/agents/maturity-scout.agent.md).
+- Workflow: [`.github/workflows/maturity-scan.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/workflows/maturity-scan.yml).


### PR DESCRIPTION
Implements #110.

## What ships

- `.github/agents/maturity-scout.agent.md` — full agent definition mirroring the structure of `@request-intake`. Read-only by default, defines on-demand and weekly modes, dedupe rules (>=70% overlap against open issues, closed-90d issues, and board #15 items), four-section filed-issue body shape, and source/area label discipline.
- `.github/workflows/maturity-scan.yml` — `workflow_dispatch` + weekly cron (Mondays 14:00 UTC), `permissions: contents: read, issues: write`, repo-hygiene-only deterministic checks (no live external fetches), dedupe pass via `gh`, attaches filed issues to board #15 via `actions/add-to-project` (SHA-pinned, `BUG_PROJECT_TOKEN` PAT). Caps filings at 5 per cron run by default.
- `wiki/Maturity-Scout.md` — documents agent, sources, dedupe rules, weekly automation contract, and PAT scope-split rationale.
- `.github/agents/README.md` — registers `@maturity-scout` in the index table.

Scaffolding (labels + Boards.md row) shipped earlier on this branch in 28d89f2.

## Tested

- Lint scope is HTML/CSS only; the changes are markdown + YAML so `npm run lint` is not relevant. Workflow YAML structure mirrors existing `board-autoadd.yml` and `bug-autoadd.yml` patterns.
- No live workflow run yet — the cron will fire on the next Monday or can be triggered manually via `workflow_dispatch`.

## Checklist

- [x] Agent file follows the structure of `request-intake.agent.md`.
- [x] Agent registered in `.github/agents/README.md`.
- [x] Dedupe step queries open issues, closed-90d issues, and every item on board #15.
- [x] On-demand mode requires explicit per-item approval before any mutation.
- [x] Workflow has `workflow_dispatch` + weekly cron, least-privilege permissions, SHA-pinned third-party action.
- [x] Filed issues use the four-section body and `source:*` labels.
- [x] `wiki/Maturity-Scout.md` documents the contract; `wiki/Boards.md` already documents board #15.

Closes #110.
