### PR TITLE
Fix YAML block-scalar parse error in maturity-scan.yml

### DIFF
--- a/.github/workflows/maturity-scan.yml
+++ b/.github/workflows/maturity-scan.yml
@@ -55,28 +55,14 @@ jobs:
             CHECKS+=("$1")
           }
 
+          # Issue body is rendered from an external template so the YAML
+          # block scalar isn't broken by an inline heredoc (see issue #115).
+          # Template lives at .github/workflows/templates/repo-hygiene-issue-body.md
+          # and uses __PATH__ as the only placeholder. read_body takes the
+          # path as $1 (the title argument is no longer needed because the
+          # template references only the path).
           read_body () {
-            cat <<EOF
-## Source
-
-GitHub repository community standards — <https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions>
-
-> GitHub recommends a baseline of community health files (\`$2\`) so contributors and consumers know what to expect.
-
-## Why it matters
-
-The portfolio repo is public. Missing \`$2\` weakens the contributor and reviewer signal and lowers the GitHub community-profile score, which is one of the visible maturity indicators on the public repo page.
-
-## Suggested change
-
-Add \`$2\` at the documented location with portfolio-appropriate content. Keep it minimal but real — no placeholder text.
-
-## Acceptance criteria
-
-- [ ] \`$2\` exists at the canonical path.
-- [ ] Content is reviewed (not template boilerplate).
-- [ ] Wiki / README cross-links updated if applicable.
-EOF
+            sed "s|__PATH__|$1|g" .github/workflows/templates/repo-hygiene-issue-body.md
           }
 
           # path | title-suffix | label-area
@@ -148,7 +134,7 @@ EOF
             fi
 
             # Build body and file the issue.
-            BODY=$(read_body "$TITLE" "$CHECK_PATH")
+            BODY=$(read_body "$CHECK_PATH")
             BODY_FILE=$(mktemp)
             printf '%s\n' "$BODY" > "$BODY_FILE"
 

--- a/.github/workflows/templates/repo-hygiene-issue-body.md
+++ b/.github/workflows/templates/repo-hygiene-issue-body.md
@@ -1,0 +1,19 @@
+## Source
+
+GitHub repository community standards — <https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions>
+
+> GitHub recommends a baseline of community health files (`__PATH__`) so contributors and consumers know what to expect.
+
+## Why it matters
+
+The portfolio repo is public. Missing `__PATH__` weakens the contributor and reviewer signal and lowers the GitHub community-profile score, which is one of the visible maturity indicators on the public repo page.
+
+## Suggested change
+
+Add `__PATH__` at the documented location with portfolio-appropriate content. Keep it minimal but real — no placeholder text.
+
+## Acceptance criteria
+
+- [ ] `__PATH__` exists at the canonical path.
+- [ ] Content is reviewed (not template boilerplate).
+- [ ] Wiki / README cross-links updated if applicable.


### PR DESCRIPTION
## Summary

Fixes the broken YAML in `.github/workflows/maturity-scan.yml` that has been failing every push to `main` since PR #111 with `Invalid workflow file ... line 62` and a downstream HTTP 422 on `gh workflow run`.

Root cause: the `read_body ()` shell function used a `cat <<EOF` heredoc whose body lines started at column 0. That ended the surrounding `run: |` YAML block scalar early.

Fix: extract the issue-body template to `.github/workflows/templates/repo-hygiene-issue-body.md` with a single `__PATH__` placeholder and render it from the step with `sed`. This sidesteps the heredoc trap entirely and gives the planned github-docs (#112) and wcag (#113) extensions a reusable template location.

## Tested

- `python -c "import yaml; yaml.safe_load(...)"` → parses cleanly.
- `npm run lint` → htmlhint + stylelint clean.
- Live test: dispatched the workflow on this branch (see PR check `Maturity Scout (weekly scan)` triggered manually via `gh workflow run`).

## Checklist

- [x] YAML parses (no more `Invalid workflow file` annotation)
- [x] Smallest correct change — no behavior changes to dedupe / labels / cap
- [x] Template path is reusable for #112 and #113
- [x] `Closes #115`
