### PR TITLE
Move repo-hygiene board attachment to sibling autoadd workflow

### DIFF
--- a/.github/workflows/maturity-autoadd.yml
+++ b/.github/workflows/maturity-autoadd.yml
@@ -1,0 +1,33 @@
+name: Maturity auto-add to portfolio maturity board
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: maturity-autoadd-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  add-to-project:
+    name: Add source:repo-hygiene issue to Portfolio Maturity board
+    runs-on: ubuntu-latest
+    # Trigger when the source:repo-hygiene label is applied (either at open
+    # time or later). The maturity-scan workflow files issues and applies
+    # the label, which fires this `labeled` event — the only reliable way
+    # to attach issues to a Projects v2 board from a non-issues trigger.
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'source:repo-hygiene') ||
+      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'source:repo-hygiene'))
+    steps:
+      - name: Add issue to board #15
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        with:
+          project-url: https://github.com/users/marcusjacobson/projects/15
+          # Reuses the classic-PAT secret with `project` scope. The default
+          # GITHUB_TOKEN cannot write to user-owned Projects v2 boards.
+          github-token: ${{ secrets.BUG_PROJECT_TOKEN }}

--- a/.github/workflows/maturity-scan.yml
+++ b/.github/workflows/maturity-scan.yml
@@ -162,15 +162,9 @@ jobs:
             if [[ -n "$SUMMARY_SUPPRESSED" ]]; then echo "$SUMMARY_SUPPRESSED"; fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Attach filed issues to Portfolio Maturity board (#15)
-        if: always()
-        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
-        with:
-          project-url: https://github.com/users/marcusjacobson/projects/15
-          # BUG_PROJECT_TOKEN is the shared classic PAT with `project` scope
-          # documented in repo memory. It can attach issues to user-owned
-          # Projects v2 boards but cannot mutate labels — so the scan step
-          # above applies labels with the default GITHUB_TOKEN, then this
-          # step uses the PAT to attach.
-          github-token: ${{ secrets.BUG_PROJECT_TOKEN }}
-          labeled: source:repo-hygiene
+      # Note: filed issues are attached to board #15 by the sibling
+      # workflow `.github/workflows/maturity-autoadd.yml`, which fires
+      # on the `labeled` event when the `source:repo-hygiene` label is
+      # applied. `actions/add-to-project` cannot run inside this scan
+      # job because workflow_dispatch / schedule events have no issue
+      # context in the payload.


### PR DESCRIPTION
## Summary

The `actions/add-to-project` step inside `maturity-scan.yml` never attached anything when fired from `workflow_dispatch` or `schedule` — that action reads the issue from `github.event` payload, which is empty for non-issues triggers. The recent live test of #115 confirmed it: filed issues #117–#120 had to be added to board #15 by hand.

This PR moves board attachment out of the scan job into a sibling workflow that mirrors `board-autoadd.yml`'s pattern (which already powers board #13 the same way). The new workflow listens on `issues: [opened, labeled]` and attaches when the `source:repo-hygiene` label is present.

## Changes

- New `.github/workflows/maturity-autoadd.yml` (sibling of `board-autoadd.yml`, triggers on label).
- Removed dead `actions/add-to-project` step from the scan job in `maturity-scan.yml`; left a comment pointing to the sibling workflow.

## Tested

- `python -c "import yaml; ..."` parses both files cleanly.
- `npm run lint` clean.
- Plan: after merge, re-label one of the existing repo-hygiene issues to fire the new workflow and confirm idempotent attach to board #15.

## Checklist

- [x] No new secrets — reuses `BUG_PROJECT_TOKEN`.
- [x] Action pinned to SHA (`actions/add-to-project@244f685...`).
- [x] `permissions:` minimal (`contents: read`, `issues: read`).
- [x] Concurrency group keyed on issue number.
