### PR TITLE
Extend maturity-scan to file source:github-docs candidates

### DIFF
--- a/.github/workflows/maturity-autoadd.yml
+++ b/.github/workflows/maturity-autoadd.yml
@@ -14,15 +14,16 @@ concurrency:
 
 jobs:
   add-to-project:
-    name: Add source:repo-hygiene issue to Portfolio Maturity board
+    name: Add source:repo-hygiene or source:github-docs issue to Portfolio Maturity board
     runs-on: ubuntu-latest
-    # Trigger when the source:repo-hygiene label is applied (either at open
-    # time or later). The maturity-scan workflow files issues and applies
-    # the label, which fires this `labeled` event — the only reliable way
-    # to attach issues to a Projects v2 board from a non-issues trigger.
+    # Trigger when the source:repo-hygiene or source:github-docs label is
+    # applied (either at open time or later). The maturity-scan workflow
+    # files issues and applies one of those labels, which fires this
+    # `labeled` event — the only reliable way to attach issues to a
+    # Projects v2 board from a non-issues trigger.
     if: >-
-      (github.event.action == 'labeled' && github.event.label.name == 'source:repo-hygiene') ||
-      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'source:repo-hygiene'))
+      (github.event.action == 'labeled' && (github.event.label.name == 'source:repo-hygiene' || github.event.label.name == 'source:github-docs')) ||
+      (github.event.action == 'opened' && (contains(github.event.issue.labels.*.name, 'source:repo-hygiene') || contains(github.event.issue.labels.*.name, 'source:github-docs')))
     steps:
       - name: Add issue to board #15
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2

--- a/.github/workflows/maturity-scan.yml
+++ b/.github/workflows/maturity-scan.yml
@@ -162,9 +162,129 @@ jobs:
             if [[ -n "$SUMMARY_SUPPRESSED" ]]; then echo "$SUMMARY_SUPPRESSED"; fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+          # Hand the running tally to the next step so the github-docs
+          # scan respects the same MAX cap.
+          echo "filed=$FILED" >> "$GITHUB_OUTPUT"
+
+      - name: Run github-docs checks (action SHA-pin audit) and file gap issue
+        id: scan_github_docs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          MAX="${MAX_FILED}"
+          FILED_SO_FAR="${{ steps.scan.outputs.filed }}"
+          FILED_SO_FAR="${FILED_SO_FAR:-0}"
+
+          if [[ "$FILED_SO_FAR" -ge "$MAX" ]]; then
+            echo "Hit MAX ($MAX) in repo-hygiene step; skipping github-docs scan."
+            {
+              echo ""
+              echo "## Maturity Scout — github-docs"
+              echo ""
+              echo "Skipped: MAX cap of $MAX reached by repo-hygiene step."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # ---- Scan: action SHA-pin audit on .github/workflows/*.yml.
+          # Convention (see .github/copilot-instructions.md): third-party
+          # actions must be pinned to a 40-char commit SHA. Flag every
+          # `uses:` line whose ref after `@` is not a 40-char hex SHA.
+          # Skip local action references (`uses: ./...`) and reusable
+          # workflow refs without a `@` (those are validated elsewhere).
+          FINDINGS=""
+          COUNT=0
+          shopt -s nullglob
+          for wf in .github/workflows/*.yml .github/workflows/*.yaml; do
+            # Use grep -nE to capture line numbers; tolerate no matches.
+            while IFS= read -r line; do
+              [[ -z "$line" ]] && continue
+              LINENO_HIT="${line%%:*}"
+              REST="${line#*:}"
+              # Extract the value after `uses:` — strip leading whitespace
+              # and the keyword itself.
+              USES_VAL=$(echo "$REST" | sed -E 's/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*//; s/[[:space:]]*#.*$//; s/[[:space:]]*$//')
+              # Skip local actions (start with ./ or ../).
+              [[ "$USES_VAL" == ./* || "$USES_VAL" == ../* ]] && continue
+              # Skip lines without an @ (e.g. reusable workflow refs).
+              [[ "$USES_VAL" != *@* ]] && continue
+              REF="${USES_VAL##*@}"
+              # 40-char lowercase hex => SHA-pinned, OK.
+              if [[ "$REF" =~ ^[0-9a-f]{40}$ ]]; then
+                continue
+              fi
+              FINDINGS+=$'- `'"$wf"':'"$LINENO_HIT"'` — `'"$USES_VAL"'`'$'\n'
+              COUNT=$((COUNT+1))
+            done < <(grep -nE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*[^[:space:]]+' "$wf" || true)
+          done
+          shopt -u nullglob
+
+          if [[ "$COUNT" -eq 0 ]]; then
+            echo "No unpinned third-party action references found."
+            {
+              echo ""
+              echo "## Maturity Scout — github-docs"
+              echo ""
+              echo "Filed: 0 (no unpinned action references found)"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # ---- Dedupe: open issue with the canonical title prefix and
+          # the source:github-docs label?
+          TITLE_PREFIX="Pin GitHub Actions to commit SHAs"
+          EXISTING=$(gh issue list \
+            --state open \
+            --search "in:title \"$TITLE_PREFIX\" label:source:github-docs" \
+            --json number,title,url \
+            --limit 50)
+          MATCH=$(echo "$EXISTING" | jq -r --arg p "$TITLE_PREFIX" \
+            '[.[] | select(.title | startswith($p))] | .[0] // empty | "\(.number)|\(.url)"')
+          if [[ -n "$MATCH" ]]; then
+            echo "Dedup suppressed: existing open issue $MATCH"
+            {
+              echo ""
+              echo "## Maturity Scout — github-docs"
+              echo ""
+              echo "Filed: 0"
+              echo ""
+              echo "Suppressed (dedupe): 1"
+              echo "  - action SHA-pin audit — overlaps with $MATCH"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # ---- Render body and file the consolidated issue.
+          TITLE="${TITLE_PREFIX} in ${COUNT} workflow file(s)"
+          BODY_FILE=$(mktemp)
+          # Use bash parameter expansion for placeholder substitution to
+          # avoid breaking the YAML block scalar with a heredoc (issue #115).
+          TEMPLATE=$(cat .github/workflows/templates/github-docs-issue-body.md)
+          TEMPLATE="${TEMPLATE//__COUNT__/$COUNT}"
+          # Strip trailing newline from FINDINGS so the bullet list closes cleanly.
+          FINDINGS_TRIMMED="${FINDINGS%$'\n'}"
+          TEMPLATE="${TEMPLATE//__FINDINGS__/$FINDINGS_TRIMMED}"
+          printf '%s\n' "$TEMPLATE" > "$BODY_FILE"
+
+          echo "Filing: $TITLE"
+          URL=$(gh issue create \
+            --title "$TITLE" \
+            --label "needs-triage,source:github-docs,area:workflow" \
+            --body-file "$BODY_FILE")
+          rm -f "$BODY_FILE"
+
+          {
+            echo ""
+            echo "## Maturity Scout — github-docs"
+            echo ""
+            echo "Filed: 1"
+            echo "  - $URL — $TITLE"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # Note: filed issues are attached to board #15 by the sibling
       # workflow `.github/workflows/maturity-autoadd.yml`, which fires
-      # on the `labeled` event when the `source:repo-hygiene` label is
-      # applied. `actions/add-to-project` cannot run inside this scan
-      # job because workflow_dispatch / schedule events have no issue
-      # context in the payload.
+      # on the `labeled` event when the `source:repo-hygiene` or
+      # `source:github-docs` label is applied. `actions/add-to-project`
+      # cannot run inside this scan job because workflow_dispatch /
+      # schedule events have no issue context in the payload.

--- a/.github/workflows/templates/github-docs-issue-body.md
+++ b/.github/workflows/templates/github-docs-issue-body.md
@@ -1,0 +1,27 @@
+## Source
+
+GitHub Actions security hardening — <https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions>
+
+> Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository.
+
+## Why it matters
+
+This repo's `.github/copilot-instructions.md` already states "SHAs preferred for third-party actions." A scan of `.github/workflows/*.yml` found __COUNT__ `uses:` reference(s) where the ref after `@` is not a 40-character commit SHA. Tag-pinned third-party actions can be retargeted by the upstream maintainer (or an attacker who compromises the maintainer) without any change in this repo, which silently expands the supply-chain trust boundary.
+
+## Suggested change
+
+Replace each tag/branch ref below with the commit SHA of the release that tag currently points to, and add a trailing `# v<x.y.z>` comment so the version is still legible during review. Example: `uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2`.
+
+Findings:
+
+__FINDINGS__
+
+## Acceptance criteria
+
+- [ ] Every `uses:` line for a third-party action in `.github/workflows/*.yml` is pinned to a 40-character commit SHA.
+- [ ] Each pinned line carries a trailing `# v<tag>` comment so the human-readable version is still visible.
+- [ ] No regressions in required PR checks after the repin.
+
+## Notes
+
+`actions/*` (first-party GitHub) lines are also flagged for consistency with the repo convention; downgrade to `wontfix` per line if the reviewer decides tag pinning is acceptable for first-party actions only.

--- a/wiki/Maturity-Scout.md
+++ b/wiki/Maturity-Scout.md
@@ -68,10 +68,11 @@ The `.github/workflows/maturity-scan.yml` workflow runs on:
 
 What it does:
 
-- Scope is restricted to `source:repo-hygiene`. The other sources require LLM judgment for relevance and dedupe and stay in on-demand chat mode.
+- Scope is restricted to `source:repo-hygiene` and `source:github-docs`. The other sources require LLM judgment for relevance and dedupe and stay in on-demand chat mode.
+- `source:github-docs` v1 covers the action SHA-pin audit only — it scans every `.github/workflows/*.yml` file and files **one consolidated issue** per run when any `uses:` ref is not pinned to a 40-character commit SHA. Other github-docs checks (CODEOWNERS shape, branch-protection doc completeness) remain on-demand under `@maturity-scout` until added in a follow-up.
 - Runs deterministic file-existence checks against the checkout (no live external fetches).
 - Performs the same dedupe pass against open issues and board items via `gh`.
-- Files each surviving candidate with `needs-triage`, `source:repo-hygiene`, and the matching `area:*` label.
+- Files each surviving candidate with `needs-triage`, the matching `source:*` label, and the matching `area:*` label.
 - Uses `actions/add-to-project` (pinned by SHA) with the shared `BUG_PROJECT_TOKEN` classic PAT to attach to board #15. The default `GITHUB_TOKEN` cannot write Projects v2; the PAT scope-split is documented in the repo's stored agent memory.
 - Caps filings at `max` per run (default 5 for the cron, overridable via `workflow_dispatch` input).
 - Posts a `Filed: <n>; Suppressed: <m>` summary to the workflow run log.


### PR DESCRIPTION
## Summary

Extends `.github/workflows/maturity-scan.yml` to file `source:github-docs` candidate issues. v1 scope is **one consolidated action SHA-pin audit issue per scan run**.

## What changed

- New body template `.github/workflows/templates/github-docs-issue-body.md` with `__FINDINGS__` / `__COUNT__` placeholders, four-section shape mirroring `repo-hygiene-issue-body.md`.
- New scan step `scan_github_docs` in `maturity-scan.yml` that runs after the repo-hygiene step, shares the same `MAX` cap (via `steps.scan.outputs.filed`), and walks every `.github/workflows/*.y(a)ml` file flagging any `uses:` line whose ref after `@` is not a 40-char hex SHA. Skips local actions (`./...`) and reusable workflow refs without `@`.
- Dedupes by searching for an open issue with title prefix `Pin GitHub Actions to commit SHAs` and label `source:github-docs`.
- Files **one** consolidated issue with labels `needs-triage,source:github-docs,area:workflow`. Body rendered with bash parameter expansion (no heredoc — avoids the issue-#115 block-scalar trap).
- `.github/workflows/maturity-autoadd.yml` `if:` filter now also triggers on `source:github-docs` for both `labeled` and `opened` actions.
- `wiki/Maturity-Scout.md` lists `source:github-docs` in the automated set with a one-line v1 scope note.

## Out of scope (deferred follow-ups)

- File-existence checks for CODEOWNERS, branch-protection docs (would overlap with repo-hygiene `TARGETS`).
- Live GitHub-docs fetches (kept on-demand per the existing comment block).
- Per-finding issues — v1 emits one consolidated issue.

## Tested

- [x] `npm run lint` passes (htmlhint + stylelint).
- [x] `python -c "yaml.safe_load(...)"` parses both modified workflows cleanly.
- [x] Dedupe logic verified by inspection: title-prefix + label search via `gh issue list --search 'in:title "Pin GitHub Actions to commit SHAs" label:source:github-docs'` short-circuits before filing.
- [ ] `gh workflow run maturity-scan.yml` not executed pre-merge (would file a real issue). Verified via `workflow_dispatch` after merge.

## Acceptance criteria (#112)

- [x] `maturity-scan.yml` has a second TARGETS-style block for github-docs checks (action SHA-pin audit).
- [x] Filed issues carry `source:github-docs` and route to board #15 via `maturity-autoadd.yml` extension.
- [ ] Manual `gh workflow run` dry-run produces zero duplicates — verified post-merge via `workflow_dispatch`.

Closes #112
