### PR TITLE
boards-worker session: Portfolio Maturity (2026-04-26)

### DIFF
--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -34,6 +34,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 - **Per-issue transitions:**
   - #112 Todo → In Progress at 2026-04-26T21:21:21-07:00
   - #112 In Progress → Done — PR #125, merge `28a011d`
+  - Filed follow-ups #126 (Option B — `@axe-core/cli`) and #127 (Option C — Playwright + axe) and attached both to board #15
+  - #113 Todo → In Progress at 2026-04-26T21:35:12-07:00
 - **Outcome:** _(filled in at session close)_
 
 ### 2026-04-26 — create Portfolio Maturity board (#15)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -32,7 +32,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 - **Status field options captured:** Todo=`f75ad846`, In Progress=`47fc9ee4`, Done=`98236657` (no `In review`-style option — per the alias table in `boards-worker.agent.md`, on-failure items stay at In Progress and the blocker is audit-logged)
 - **Schema mutations applied:** _(none — board #15 schema unchanged for this run)_
 - **Per-issue transitions:**
-  - _(filled in as the batch runs)_
+  - #112 Todo → In Progress at 2026-04-26T21:21:21-07:00
+  - #112 In Progress → Done — PR #125, merge `28a011d`
 - **Outcome:** _(filled in at session close)_
 
 ### 2026-04-26 — create Portfolio Maturity board (#15)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -37,6 +37,7 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - Filed follow-ups #126 (Option B — `@axe-core/cli`) and #127 (Option C — Playwright + axe) and attached both to board #15
   - #113 Todo → In Progress at 2026-04-26T21:35:12-07:00
   - #113 In Progress → Done — PR #128, merge `2356279`
+  - #114 Todo → In Progress at 2026-04-26T21:46:54-07:00
 - **Outcome:** _(filled in at session close)_
 
 ### 2026-04-26 — create Portfolio Maturity board (#15)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -36,6 +36,7 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #112 In Progress → Done — PR #125, merge `28a011d`
   - Filed follow-ups #126 (Option B — `@axe-core/cli`) and #127 (Option C — Playwright + axe) and attached both to board #15
   - #113 Todo → In Progress at 2026-04-26T21:35:12-07:00
+  - #113 In Progress → Done — PR #128, merge `2356279`
 - **Outcome:** _(filled in at session close)_
 
 ### 2026-04-26 — create Portfolio Maturity board (#15)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -38,7 +38,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #113 Todo → In Progress at 2026-04-26T21:35:12-07:00
   - #113 In Progress → Done — PR #128, merge `2356279`
   - #114 Todo → In Progress at 2026-04-26T21:46:54-07:00
-- **Outcome:** _(filled in at session close)_
+  - #114 In Progress → Done — PR #129, merge `09317f6`
+- **Outcome:** Clean drain. 3/3 of the Todo queue (#112, #113, #114) shipped this session; 2 follow-ups filed and added to board #15 (#126 Option B `@axe-core/cli`, #127 Option C Playwright + axe-core). Source `source:wcag` is now automated (v1: regex-only checks for `lang` attr, empty link text, heading order). Operator runbook documented in `wiki/Maturity-Scout.md`. Board #15 has 0 items in In Progress at session close. Lychee flagged a transient LinkedIn `999` anti-bot response on PR #129 (cleared by `gh run rerun --failed`) — captured as a possible future follow-up if recurrent.
 
 ### 2026-04-26 — create Portfolio Maturity board (#15)
 

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -24,6 +24,17 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 
 ## Sweep log
 
+### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)
+
+- **Branch:** `boards-worker/maturity-20260426-2120` — PR _(opened at session close)_
+- **Operator:** boards-worker agent
+- **Queue at start (Todo):** #112, #113, #114
+- **Status field options captured:** Todo=`f75ad846`, In Progress=`47fc9ee4`, Done=`98236657` (no `In review`-style option — per the alias table in `boards-worker.agent.md`, on-failure items stay at In Progress and the blocker is audit-logged)
+- **Schema mutations applied:** _(none — board #15 schema unchanged for this run)_
+- **Per-issue transitions:**
+  - _(filled in as the batch runs)_
+- **Outcome:** _(filled in at session close)_
+
 ### 2026-04-26 — create Portfolio Maturity board (#15)
 
 Inputs: user request via `@request-intake` → `@board-planner` — "create an agent that scans the repo on demand or weekly and adds issues to a board for areas I can mature the repo or live portfolio based on Microsoft Learn, GitHub docs, and other well-known best practices; dedupe against existing recommendations." Board needed up front so the agent-build issue and all future scanner output land in one place.


### PR DESCRIPTION
# boards-worker session: Portfolio Maturity (2026-04-26)

Drains the Todo queue on board #15 (Portfolio Maturity).

## Queue worked

| # | Title | PR | Merge SHA |
|---|---|---|---|
| #112 | maturity-scan: extend repo-hygiene to GitHub Docs sources | #125 | `28a011d` |
| #113 | Extend maturity-scan to cover source:wcag via static a11y checks | #128 | `2356279` |
| #114 | Document maturity-scan operator runbook | #129 | `09317f6` |

## Follow-ups filed (added to board #15)

- #126 — Extend source:wcag scan to `@axe-core/cli` (broader WCAG-A/AA rules) — Option B deferred
- #127 — Extend source:wcag scan to Playwright + `@axe-core/playwright` (full DOM, contrast) — Option C deferred

## Audit log

This branch only edits `wiki/Boards.md` to record the session transitions (Todo → In Progress → Done) and the outcome line. No code changes — all functional changes shipped via PR #125, #128, #129 against `main`.

## Tested checklist

- [x] All three issues squash-merged with `--admin` and branches deleted
- [x] Each PR's required checks passed: `scan`, `lint`, `lychee`, `label`, `analyze (javascript-typescript)`
- [x] Board #15 transitions applied (Todo → In Progress → Done) with timestamps captured
- [x] AC checkboxes ticked on each issue and resolution comments posted
- [x] #126 / #127 attached to board #15
