### PR TITLE
docs(wiki): add Build mechanics index to Home (#141)

### DIFF
--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -17,3 +17,16 @@ Welcome to the wiki. This is the source of truth for project notes, runbooks, an
 - [Publishing-Workflow](Publishing-Workflow) — How content reaches the live site.
 - [Security-Review-Checklist](Security-Review-Checklist) — What gets verified on every PR.
 - [Site-Architecture](Site-Architecture) — Page layout and tooling overview.
+
+## Build mechanics
+
+How this repo is wired — the agents, prompts, workflows, and rules that turn a chat request into a merged PR and a published site. Start here if you want to understand or extend the automation rather than the portfolio content itself.
+
+- [Repo-Architecture](Repo-Architecture) — Folder map and the chat-prompt-to-merged-PR intake flow.
+- [Agents](Agents) — Local chat-mode agents and the hosted Copilot coding agent that build and maintain this repo.
+- [Prompts](Prompts) — Slash-command prompts under `.github/prompts/` and the agents they hand off to.
+- [Workflows](Workflows) — GitHub Actions catalog: triggers, permissions, secrets, and which checks block PR merges.
+- [Deployment-Rules](Deployment-Rules) — Branch protection, required status contexts, and the Pages deploy contract.
+- [Boards](Boards) — GitHub Projects v2 audit log, schemas, and sweep history.
+- [Maturity-Scout](Maturity-Scout) — The repo-hygiene scanner that files gap issues against authoritative sources.
+- [Terminology](Terminology) — "Project" (portfolio) vs "Board" (GitHub Projects v2). Read this first.


### PR DESCRIPTION
## Summary

Adds a "Build mechanics" index section to `wiki/Home.md` so the build-docs pages (Repo-Architecture, Agents, Prompts, Workflows, Deployment-Rules, Boards, Maturity-Scout, Terminology) can be found as a cluster, separate from the portfolio-content pages.

The existing "Sections" list is left unchanged — no portfolio-content links were moved.

Closes #141

## Tested

- [x] `npm run lint` passes (htmlhint + stylelint).
- [x] All linked wiki pages exist under `wiki/`.
- [x] No reordering of existing entries in the "Sections" list.
