### PR TITLE
feat(wiki-sync): define state-file schema and seed cursor (#144)

### DIFF
--- a/.copilot-tracking/README.md
+++ b/.copilot-tracking/README.md
@@ -1,0 +1,42 @@
+# `.copilot-tracking/`
+
+Durable, audit-friendly state files used by the repo's Copilot agents. Files here **are tracked in git** so every state transition is visible in PR diffs and `git log`. This folder is intentionally **not** in `.gitignore`.
+
+> If you ever need to suppress audit noise for a high-frequency cursor, the documented fallback is a repo variable (e.g. `gh variable set WIKI_SYNC_LAST_SHA`). Record that decision in the PR that introduces the change.
+
+## Files
+
+| File | Owner | Purpose |
+|------|-------|---------|
+| [`wiki-sync-state.json`](wiki-sync-state.json) | [`@wiki-sync`](../../wiki/Agents.md) (design tracked in [#143](https://github.com/marcusjacobson/portfolio/issues/143)) | Last-processed commit SHA + last batch summary. Schema: [`wiki-sync-state.schema.json`](wiki-sync-state.schema.json). |
+
+## `wiki-sync-state.json` schema
+
+The contract is enforced by [`wiki-sync-state.schema.json`](wiki-sync-state.schema.json). At a glance:
+
+```jsonc
+{
+  "lastProcessedSha": "<40-char SHA on main>",
+  "lastRunAt": "<ISO-8601 UTC, e.g. 2026-04-27T12:25:39Z>",
+  "lastBatchSummary": {
+    "filed":     [/* issue numbers or short ids the agent handed off */],
+    "deferred":  [/* items flagged but not filed this run */],
+    "cancelled": [/* items the operator dismissed this run */]
+  }
+}
+```
+
+Field rules:
+
+- `lastProcessedSha` — full 40-character SHA. The next `@wiki-sync` run computes the delta `lastProcessedSha..HEAD` against `wiki/**`.
+- `lastRunAt` — ISO-8601 UTC timestamp with the `Z` suffix.
+- `lastBatchSummary.{filed,deferred,cancelled}` — all three keys are required; empty arrays are valid (the seed entry uses empty arrays).
+- The optional `_seed` object documents the initial commit and is removed (or overwritten) on the first real `@wiki-sync` run.
+
+## Update protocol
+
+`@wiki-sync` overwrites this file at the end of every batch as part of the same PR/commit that files the delta issues, so the cursor advance and the audit trail land together. Operators editing this file by hand should:
+
+1. Validate against the schema before committing.
+2. Use an imperative commit subject like `chore(wiki-sync): advance cursor to <short-sha>`.
+3. Never push directly to `main` — open a PR per repo conventions.

--- a/.copilot-tracking/wiki-sync-state.json
+++ b/.copilot-tracking/wiki-sync-state.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "./wiki-sync-state.schema.json",
+  "lastProcessedSha": "bb5aa4c62c78faaa2b466ad8f16464cb98fb5a64",
+  "lastRunAt": "2026-04-27T12:25:39Z",
+  "lastBatchSummary": {
+    "filed": [],
+    "deferred": [],
+    "cancelled": []
+  },
+  "_seed": {
+    "note": "Initial seed committed with PR for issue #144. The wiki-sync agent (issue #143) has not yet run; this SHA marks the baseline from which the first delta will be computed.",
+    "issue": "https://github.com/marcusjacobson/portfolio/issues/144"
+  }
+}

--- a/.copilot-tracking/wiki-sync-state.schema.json
+++ b/.copilot-tracking/wiki-sync-state.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/marcusjacobson/portfolio/.copilot-tracking/wiki-sync-state.schema.json",
+  "title": "wiki-sync state file",
+  "description": "Durable cursor for the @wiki-sync detector agent (see issues #143, #144, #145). Records the last commit SHA whose wiki/** delta was fully resolved (filed / deferred / cancelled) so the next run only inspects newer commits.",
+  "type": "object",
+  "required": ["lastProcessedSha", "lastRunAt", "lastBatchSummary"],
+  "additionalProperties": true,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional pointer to this schema. Tooling-only; @wiki-sync does not require it."
+    },
+    "lastProcessedSha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "Full 40-char SHA of the most recent commit on main whose wiki/** delta was fully resolved by @wiki-sync. The next run computes the diff lastProcessedSha..HEAD."
+    },
+    "lastRunAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC timestamp (suffix Z) of when @wiki-sync last finished a batch."
+    },
+    "lastBatchSummary": {
+      "type": "object",
+      "description": "Outcome of the most recent batch. Each array holds issue/PR numbers or short identifiers; empty arrays are valid (e.g. seed entry).",
+      "required": ["filed", "deferred", "cancelled"],
+      "additionalProperties": false,
+      "properties": {
+        "filed": {
+          "type": "array",
+          "description": "Items the agent successfully handed off (e.g. to @request-intake or @board-planner) and that produced a tracked issue or board item.",
+          "items": { "type": ["string", "integer"] }
+        },
+        "deferred": {
+          "type": "array",
+          "description": "Items the agent flagged but chose not to file this run (e.g. waiting on a parent issue, or below threshold).",
+          "items": { "type": ["string", "integer"] }
+        },
+        "cancelled": {
+          "type": "array",
+          "description": "Items the agent or operator explicitly dismissed during this batch (won't be re-detected unless reverted).",
+          "items": { "type": ["string", "integer"] }
+        }
+      }
+    },
+    "_seed": {
+      "type": "object",
+      "description": "Optional metadata about the initial seed entry. Removed or overwritten on the first real @wiki-sync run.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ test-results/
 .lighthouseci/
 *.log
 
+# Agent state. .copilot-tracking/ is intentionally tracked in git for auditability;
+# this comment exists so future contributors don't add it to the ignore list by reflex.
+# See .copilot-tracking/README.md.
+


### PR DESCRIPTION
## Summary

Defines the durable cursor for the upcoming `@wiki-sync` detector agent (design tracked in #143, invocation prompt in #145). This unblocks both follow-ups by pinning the file path, schema, and seed value before any agent code is written.

## Changes

- `.copilot-tracking/wiki-sync-state.json` — initial seed pinned to current `main` HEAD `bb5aa4c`, with empty `filed`/`deferred`/`cancelled` arrays and a `_seed` block linking back to #144.
- `.copilot-tracking/wiki-sync-state.schema.json` — JSON Schema (Draft 2020-12) enforcing `lastProcessedSha` (40-char hex), `lastRunAt` (ISO-8601 UTC), and the `lastBatchSummary` shape.
- `.copilot-tracking/README.md` — documents the folder purpose, the schema at-a-glance, and the update protocol.
- `.gitignore` — adds an explanatory comment confirming `.copilot-tracking/` is intentionally tracked.

## Acceptance criteria

- [x] State file path agreed and documented — `.copilot-tracking/wiki-sync-state.json`, called out in `.copilot-tracking/README.md`.
- [x] Schema captured — `lastProcessedSha`, `lastRunAt`, `lastBatchSummary.{filed,deferred,cancelled}` enforced via `wiki-sync-state.schema.json`.
- [x] `.gitignore` rules confirmed (file IS tracked) — verified via `git check-ignore` (no match); explanatory comment added.
- [x] Initial seed entry committed with the SHA at which wiki-sync first goes live — seeded to `bb5aa4c62c78faaa2b466ad8f16464cb98fb5a64`.

## Decision: file vs repo variable

Chose the committed-file path (the issue's primary proposal) for full audit visibility in PR diffs and `git log`. The repo-variable fallback (`gh variable set WIKI_SYNC_LAST_SHA`) is documented in `.copilot-tracking/README.md` as the escape hatch if audit noise becomes a concern.

## Tested

- [x] `npm run lint` — both `lint:html` and `lint:css` pass.
- [x] `git check-ignore` confirms none of the new files are ignored.
- [x] JSON files parse cleanly against the schema rules locally.

Closes #144.
