### PR TITLE
chore(agents): recognize @wiki-sync handoffs in request-intake (#148)

### DIFF
--- a/.github/agents/request-intake.agent.md
+++ b/.github/agents/request-intake.agent.md
@@ -39,6 +39,37 @@ The user's prompt itself. Optionally:
 - A board hint (`for Compass v-next`, `add to board #11`).
 - A priority hint (`p0`, `urgent`, `someday`).
 
+## Handoff inputs (from other agents)
+
+In addition to free-form chat requests, this agent also accepts pre-classified drafts handed off from other agents (currently `@wiki-sync`; see issues #143, #144, #145). A handoff is a JSON-shaped payload, not a natural-language prompt, and signals that classification has already been done upstream.
+
+Shape:
+
+```json
+{
+  "type": "feat | bug | chore | docs",
+  "paths": ["wiki/Foo.md", "..."],
+  "suggestedTitle": "<imperative ≤72 chars>",
+  "suggestedBody": "<markdown body, may already include ## Context / ## Acceptance criteria>",
+  "suggestedLabels": ["area:docs", "..."],
+  "sourceAgent": "wiki-sync"
+}
+```
+
+Behavior on handoff:
+
+- **Skip step 1 (Classify).** Use the upstream `type` as-is.
+- **Step 2 (Discover existing context) still runs** — duplicate detection and live `gh label list` validation are non-negotiable, even on handoffs. Drop any `suggestedLabels` entry that doesn't appear in the live label list and surface the drop in the proposal.
+- **Step 3 (Draft).** Seed `Title` from `suggestedTitle` and `Body` from `suggestedBody`. The agent may tighten wording or reformat to match the standard `## Context / ## Acceptance criteria / ## Notes` shape, but must not invent new acceptance criteria not present in the handoff.
+- **Auto-included labels by `sourceAgent`:**
+    - `sourceAgent == "wiki-sync"` → always include `agent:wiki-sync` (in addition to the validated `suggestedLabels`).
+- **Default board routing by `sourceAgent` (overridable by user or by an explicit board hint in the handoff):**
+    - `sourceAgent == "wiki-sync"` → board #16 "Wiki & Build-Docs Automation". Skip the step-4 routing logic; go straight to "Add to existing board #16" in the proposal. The user may still override at approval time (`edit: file unattached` or `edit: board #<N>`).
+- **Step 5 (Present the proposal), step 6 (Wait for approval), and step 7 (Mutate) are unchanged.** Handoffs do not auto-apply — the user still confirms before any `gh` mutation runs.
+- **`sourceAgent` and `paths` are recorded** in the issue body's `## Notes` section so the trail back to the upstream agent is preserved (e.g., `Source: @wiki-sync — paths: wiki/Foo.md, wiki/Bar.md`).
+
+If `sourceAgent` is missing or set to a value this agent does not recognize, treat the payload as a normal chat-driven request and run the full workflow from step 1.
+
 ## Workflow
 
 ### 1. Classify


### PR DESCRIPTION
## Summary

Closes #148. Extends `.github/agents/request-intake.agent.md` to recognize JSON-shaped handoff payloads from `@wiki-sync` (per the state-file schema landed in #144 / PR #158) without disturbing the chat-driven intake flow.

## Changes

- New top-level **Handoff inputs (from other agents)** section between `Inputs` and `Workflow` documenting the accepted shape `{type, paths, suggestedTitle, suggestedBody, suggestedLabels, sourceAgent}`.
- When `sourceAgent == "wiki-sync"`:
    - Default board routing = board #16 "Wiki & Build-Docs Automation" (overridable at approval time).
    - `agent:wiki-sync` label auto-included alongside validated `suggestedLabels`.
    - Classification is skipped (upstream `type` is used as-is); duplicate detection and live label validation still run.
    - `sourceAgent` and `paths` are recorded in the filed issue's Notes so the source trail is preserved.
- Unknown or missing `sourceAgent` falls back to the standard chat-driven workflow — no regression.

## Tested

- [x] `npm run lint` (htmlhint + stylelint) — clean.
- [x] Manual diff review — only the `request-intake.agent.md` agent file changed; no script or workflow touched.
- [x] AC cross-check vs #148:
    - [x] Handoff inputs section present and documents the full shape.
    - [x] `sourceAgent == "wiki-sync"` defaults to board #16 (overridable).
    - [x] `sourceAgent == "wiki-sync"` auto-includes `agent:wiki-sync`.
    - [x] Existing chat-driven flow unchanged for inputs without `sourceAgent`.
