### PR TITLE
Add agent:* labels to labels.yml manifest

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -61,6 +61,17 @@
   color: 5319e7
   description: General repo hygiene best practice (CODEOWNERS, SECURITY.md, dependency review, etc).
 
+# Agent (tasks scoped to a specific automation agent build or its findings)
+- name: agent:wiki-sync
+  color: 8957e5
+  description: Tasks for the wiki-sync agent build or its findings
+- name: agent:linkedin-sync
+  color: 0e8a16
+  description: Tasks for the LinkedIn-Portfolio sync agent build or its findings
+- name: agent:copilot-enablement
+  color: 8957e5
+  description: Tasks to enable and operate the GitHub Copilot cloud agent on this repo
+
 # Lifecycle
 - name: needs-triage
   color: fef2c0


### PR DESCRIPTION
Persists `agent:wiki-sync`, `agent:linkedin-sync`, and `agent:copilot-enablement` in `.github/labels.yml` so `scripts/gh/sync-labels.ps1` keeps them on future runs.

## Acceptance criteria
- [x] `.github/labels.yml` contains an `agent:wiki-sync` entry under a new agent-label section, color `8957e5`, with description.
- [x] `sync-labels.ps1 -DryRun` reports no diff after the change (verified locally — all three agent labels show `OK`).

## Housekeeping
- Added `agent:linkedin-sync` (color `0e8a16`) and `agent:copilot-enablement` (color `8957e5`) at the same time so the manifest matches the live label set.

Closes #142
