### PR TITLE
docs: document @linkedin-sync agent in wiki and README

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,7 @@ This is a static HTML portfolio site published to GitHub Pages. There is **no bu
 - Publishing → use `/publish-update` prompt or the `@publish-manager` agent.
 - Security review → use `/secure-code-review` prompt or `@security-reviewer` agent.
 - Issues / Boards / Wiki ops → use `@repo-ops` (uses `gh` CLI and the GitHub MCP server).
+- LinkedIn / profile / sync (audit drift between portfolio and LinkedIn) → use the `@linkedin-sync` agent. See [wiki/LinkedIn-Sync.md](../wiki/LinkedIn-Sync.md) for the input contract, gap categories, and run modes.
 
 ## Request intake (always-on)
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The site is hosted via [GitHub Pages](https://pages.github.com/) using the moder
 | [.github/workflows/](.github/workflows/) | CI: deploy, link/HTML/CSS/visual checks, CodeQL, gitleaks, wiki sync, labeler. |
 | [.github/copilot-instructions.md](.github/copilot-instructions.md) + [.github/instructions/](.github/instructions/) | Repo-wide and scoped Copilot guidance. |
 | [.github/prompts/](.github/prompts/) | Slash-command tasks: `/publish-update`, `/secure-code-review`, `/triage-issue`, `/groom-backlog`. |
-| [.github/agents/](.github/agents/) | Chat agents: `@publish-manager`, `@security-reviewer`, `@repo-ops`. |
+| [.github/agents/](.github/agents/) | Chat agents: `@publish-manager`, `@security-reviewer`, `@repo-ops`, `@linkedin-sync` ([wiki](wiki/LinkedIn-Sync.md)). See [wiki/Agents.md](wiki/Agents.md) for the full catalog. |
 | [.github/ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/) + [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) | Templates for repeatable intake. |
 | [.github/labels.yml](.github/labels.yml) | Canonical label set. Synced via [scripts/gh/sync-labels.ps1](scripts/gh/sync-labels.ps1). |
 | [scripts/](scripts/) | PowerShell ops: migration, branch protection, gh CLI helpers. |

--- a/wiki/Agents.md
+++ b/wiki/Agents.md
@@ -24,6 +24,7 @@ Frontmatter source: each row's purpose is the agent's `readme-summary:` (truncat
 | [`@publish-manager`](https://github.com/marcusjacobson/portfolio/blob/main/.github/agents/publish-manager.agent.md) | Orchestrates a portfolio publish: local validation, branch, commit, push, PR, and check-watching. | Page changes are sitting in the working tree and need to ship. | `@security-reviewer` for the resulting PR. |
 | [`@security-reviewer`](https://github.com/marcusjacobson/portfolio/blob/main/.github/agents/security-reviewer.agent.md) | Reviews a PR diff for XSS, secret leakage, supply-chain risk, unsafe workflow permissions, and CDN trust. Read-only. | Before merging any PR that touches HTML/JS, workflows, or dependencies. | None — emits a verdict (`APPROVE` / `REQUEST CHANGES` / `COMMENT`). |
 | [`@maturity-scout`](https://github.com/marcusjacobson/portfolio/blob/main/.github/agents/maturity-scout.agent.md) | Scans the repo against Microsoft Learn, GitHub docs, OWASP, WCAG, and repo-hygiene best practices and surfaces gap issues onto the Portfolio Maturity board (#15). | Periodic best-practice audit, or after a major external standard updates. Also runs weekly via [`maturity-scan.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/workflows/maturity-scan.yml). | `@request-intake` (chat triage) or `@boards-worker` (batch drain). |
+| [`@linkedin-sync`](LinkedIn-Sync) | Compares portfolio claims against the user's LinkedIn profile snapshot and files `gap:*` issues for missing, stale, or misaligned items. Also runs a static best-practice checklist on every invocation. See [LinkedIn Sync](LinkedIn-Sync) for the full design. | User says "sync LinkedIn", "check profile drift", or wants to audit cert / project / skill parity between portfolio and LinkedIn. | `@issue-resolver` (single finding) or `@boards-worker` (drain the gap backlog). |
 | [`@repo-ops`](https://github.com/marcusjacobson/portfolio/blob/main/.github/agents/repo-ops.agent.md) | Generic catch-all for Issues, Projects, Labels, and Wiki ops driven by `gh` CLI and the GitHub MCP server. | Ad-hoc label syncs, wiki edits, or `gh` operations that don't fit another agent. | None — terminal step. |
 
 ## How they hand off
@@ -55,6 +56,9 @@ flowchart TD
 
     scout["@maturity-scout"] --> req
     scout --> worker
+
+    linkedin["@linkedin-sync"] --> resolver
+    linkedin --> worker
 
     ops["@repo-ops"]:::side
     classDef side stroke-dasharray: 4 4

--- a/wiki/LinkedIn-Sync.md
+++ b/wiki/LinkedIn-Sync.md
@@ -1,0 +1,113 @@
+# LinkedIn Sync
+
+`@linkedin-sync` is a chat-mode agent that compares the claims on this portfolio (HTML pages, certs, projects, skills) against a snapshot of the user's LinkedIn profile and files **gap issues** for anything that is missing, stale, or misaligned. It also runs a static best-practice checklist on every invocation.
+
+The agent is designed to be re-run safely. Reruns with no new gaps create zero new issues.
+
+## Purpose
+
+Keep the public portfolio and the public LinkedIn profile telling the same story:
+
+- Every active certification on `certification_strategy.html` is also visible on LinkedIn.
+- Featured items, headline freshness, and project recency stay above defined thresholds.
+- Drift between the two surfaces shows up as actionable GitHub issues, not as something the user has to remember to audit by hand.
+
+## Input contract
+
+The agent expects one normalized claim set from each side: portfolio and LinkedIn.
+
+### Portfolio side
+
+Extracted from the static HTML pages by the claims extractor (see [issue #25](https://github.com/marcusjacobson/portfolio/issues/25)). No user action required.
+
+### LinkedIn side
+
+Pick **one** of the supported ingestion paths (see [issue #24](https://github.com/marcusjacobson/portfolio/issues/24) for the field-mapping decision):
+
+| Path | How to provide | Notes |
+|------|----------------|-------|
+| Manual paste | Paste profile sections into the chat when prompted. | Lowest friction; good for one-off runs. |
+| Data export ZIP | Download from LinkedIn → *Settings → Get a copy of your data*; drop into `staging-inbox/linkedin/` (gitignored). | Most complete; reads `Profile.csv`, `Skills.csv`, `Certifications.csv`, `Positions.csv`. |
+| Public profile URL | `linkedin.com/in/<slug>` — only with explicit opt-in for the user's own profile. | Subject to LinkedIn ToS / robots.txt; off by default. |
+
+The agent **fails closed** if no input is provided — no silent zero-gap reports.
+
+Sample fixtures live (or will live) under `tests/fixtures/linkedin/` with PII redacted.
+
+## Gap categories
+
+Findings are emitted as GitHub issues labeled `source:linkedin-sync` plus one of the `gap:*` labels below. See [issue #26](https://github.com/marcusjacobson/portfolio/issues/26) for the diff algorithm.
+
+| Category | Meaning | Default severity |
+|----------|---------|------------------|
+| `gap:missing-on-linkedin` | Portfolio asserts X; LinkedIn does not. | p2 (p1 if cert or current title) |
+| `gap:missing-on-portfolio` | LinkedIn asserts X; portfolio does not. | p2 |
+| `gap:stale-date` | Same item, dates disagree by more than 30 days. | p2 |
+| `gap:title-mismatch` | Same item, name differs (Levenshtein ≤ 3 or token-set ratio ≥ 0.85). | p1 |
+| `gap:cert-status` | Cert appears active on one side, expired or in-progress on the other. | p1 |
+| `gap:order-suggestion` | Pinned / featured order differs. | p3 |
+| `gap:best-practice` | Static-rule check failed (recency, headline length, cert visibility, etc.). | p3 |
+
+## How to run
+
+```text
+@linkedin-sync
+```
+
+The agent will:
+
+1. Prompt for LinkedIn input (or detect the export under `staging-inbox/linkedin/`).
+2. Extract portfolio claims from the HTML pages.
+3. Compute the gap set.
+4. Run the best-practice checklist (see below).
+5. Present a **numbered proposal block** of findings.
+6. Wait for explicit approval — `yes`, an edited subset (`yes 1,3,5`), or `cancel`.
+7. File the approved findings as issues and append a run summary to the [Audit log](#audit-log).
+
+### Read-only mode
+
+```text
+@linkedin-sync --report
+```
+
+Prints the gap table and best-practice findings without creating any issues. Safe to run any time.
+
+## Best-practice checklist
+
+Static rules that run every invocation, independent of the LinkedIn input. See [issue #28](https://github.com/marcusjacobson/portfolio/issues/28) for the full table.
+
+| ID | Rule | Severity |
+|----|------|----------|
+| `bp-headline-fresh` | Portfolio headline edited within last 90 days. | p3 |
+| `bp-cert-visibility` | Every active cert on `certification_strategy.html` appears on `index.html`. | p2 |
+| `bp-project-recency` | At least one project on `ms_security_projects.html` updated within last 180 days. | p3 |
+| `bp-skills-decay` | Skills with `lastUsed` > 24 months get an "archive" suggestion. | p3 |
+| `bp-featured-parity` | LinkedIn featured-items count ≥ portfolio featured-items count. | p3 |
+| `bp-headline-length` | LinkedIn headline ≤ 220 chars. | p3 |
+| `bp-open-to-work-consistency` | Portfolio availability matches LinkedIn `Open to work`. | p2 |
+
+Each rule emits at most one issue per run (deduped by rule id + finding hash).
+
+## How to interpret findings
+
+- **One finding = one issue.** Title pattern: `[linkedin-sync] <category>: <short summary>`.
+- Issue body includes the diff, both source values, the proposed fix, and a link back to this wiki page.
+- All findings carry `source:linkedin-sync`. Filter the issues view with that label to see the full backlog.
+- Severity drives the priority label (`priority:p1` / `p2` / `p3`).
+- Use `@issue-resolver` (or hand off to `@boards-worker`) to drain the backlog.
+- Closing the issue without a code change is fine — the next run won't re-file it unless the underlying gap returns.
+
+## Audit log
+
+Every run appends a row here. The agent writes the row automatically; do not hand-edit.
+
+| Date | Mode | Findings (total / new / dedup) | Top categories | Run summary |
+|------|------|--------------------------------|----------------|-------------|
+| _(no runs yet)_ | — | — | — | — |
+
+## See also
+
+- [Agents](Agents) — full chat-agent catalog and handoff diagram.
+- [Boards](Boards) — board topology where `source:linkedin-sync` issues land.
+- [Terminology](Terminology) — Project (portfolio) vs Board (GitHub Projects v2).
+- Issues that built this agent: [#24](https://github.com/marcusjacobson/portfolio/issues/24), [#25](https://github.com/marcusjacobson/portfolio/issues/25), [#26](https://github.com/marcusjacobson/portfolio/issues/26), [#27](https://github.com/marcusjacobson/portfolio/issues/27), [#28](https://github.com/marcusjacobson/portfolio/issues/28), [#29](https://github.com/marcusjacobson/portfolio/issues/29).


### PR DESCRIPTION
## Summary

Documents the `@linkedin-sync` agent across the four surfaces called out in #30:

- **`wiki/LinkedIn-Sync.md`** (new) — purpose, input contract (manual paste / data-export ZIP / public URL), gap categories, run modes (interactive + `--report`), best-practice checklist, audit log section, and a "See also" block linking back to the implementation issues (#24–#29).
- **`wiki/Agents.md`** — adds a row for `@linkedin-sync` to the local-agents catalog table and wires it into the Mermaid handoff diagram (handoff: `@issue-resolver` / `@boards-worker`).
- **`README.md`** — extends the agents bullet in the repo-layout table to include `@linkedin-sync` and points readers at `wiki/Agents.md` for the full catalog.
- **`.github/copilot-instructions.md`** — adds a routing bullet under "When the user asks to publish, review, or stage" mapping `LinkedIn / profile / sync` -> `@linkedin-sync`, with a deep link to the wiki page.

The agent file itself (`.github/agents/linkedin-sync.agent.md`) is still being authored under #27; this PR only ships the user-facing docs. Internal links use the wiki-relative `[LinkedIn-Sync](LinkedIn-Sync)` convention so the wiki sync renders them correctly.

## Acceptance

- [x] `wiki/LinkedIn-Sync.md` covers purpose, input contract, gap categories, how to run, how to interpret findings, and an audit log section.
- [x] README "Agents" listing includes a one-line entry pointing to the wiki page.
- [x] `.github/copilot-instructions.md` has a `LinkedIn / profile / sync` -> `@linkedin-sync` bullet.
- [x] All new internal links resolve (no references to the not-yet-existing agent file body — `.github/agents/` is excluded from lychee anyway).
- [x] `npm run lint` passes locally.

## Tested

- `npm run lint` — clean (htmlhint + stylelint).
- Manual review: Mermaid block in Agents.md still parses; markdown tables align; copilot-instructions bullet matches existing tone.

Closes #30.
