### PR TITLE
docs: add Agents section to README linking Projects, wiki, and AGENTS.md tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,11 @@ In VS Code chat:
 - In the agent picker, choose `publish-manager`, `security-reviewer`, or `repo-ops`.
 - The GitHub MCP server (defined in [.vscode/mcp.json](.vscode/mcp.json)) prompts for a PAT on first use; the token is never written to disk.
 
+## Agents
+
+This repo combines **local VS Code agents** (chat-mode personas under [.github/agents/](.github/agents/)) with the **GitHub Copilot cloud agent** for asynchronous, issue-driven work. Local agents handle interactive flows like publishing, security review, and intake triage; the cloud agent picks up labeled issues and opens PRs in the background. Work in flight is tracked on GitHub Projects v2 boards (Portfolio Roadmap, Bug Tracker, etc.).
+
+- [Projects tab](https://github.com/marcusjacobson/portfolio/projects) — live boards for roadmap, bugs, and intake.
+- [wiki/Agents.md](wiki/Agents.md) — full catalog of local and cloud agents with their tools and routing.
+- [AGENTS.md (planned — issue #32)](https://github.com/marcusjacobson/portfolio/issues/32) — top-level cloud-agent guidance for the hosted Copilot agent.
+


### PR DESCRIPTION
## Summary

Adds an `## Agents` section near the bottom of `README.md` (right after `## Copilot usage`) that surfaces the agent automation and the live Projects boards.

## Acceptance criteria

- [x] Top-level `## Agents` section in `README.md`.
- [x] 3–5 line description covering local VS Code agents + the hosted Copilot cloud agent + the Projects v2 boards used to track work.
- [x] Link to the GitHub Projects tab.
- [x] Link to `wiki/Agents.md` for the full catalog.
- [x] Link to `AGENTS.md` — file does not exist yet (tracked in #32), so the link points to issue #32 with `(planned — issue #32)` text. Once #32 ships, swap the URL for a relative `AGENTS.md` link.

## Notes

- Issue body referenced `AGENTS.md (issue #1)` and `wiki/Agents.md (issue #6)`, but the actual tracker numbers are #32 (open) and #136 (closed) respectively. Used the real numbers.
- README stays under quick-orient length per issue's note.

Closes #38
