### PR TITLE
docs(projects): note audit-log move and Cloud Agent Enablement (#11) location

### DIFF
--- a/wiki/Projects.md
+++ b/wiki/Projects.md
@@ -31,6 +31,10 @@ When the user wants to add a new portfolio Project (capstone, security initiativ
 
 For all non-Project intake (features, bugs, chores), see [`@request-intake`](../.github/agents/request-intake.agent.md) and [`@bug-intake`](../.github/agents/bug-intake.agent.md).
 
+## Note on the audit log move
+
+The GitHub Projects v2 audit log (every Board on this user account, including internal-tooling boards like **Cloud Agent Enablement** (#11) — Source field `config / docs / smoke-test`, seeded issues #32–#40, complementary to board #10 LinkedIn / Portfolio Sync via Option B manual handoff using the `agent-task` label) now lives in [Boards](Boards). It used to live here, until the terminology split (PR #98) gave Boards their own page. This page now covers portfolio Projects only.
+
 ## See also
 
 - [Boards](Boards) — GitHub Projects v2 audit log, schemas, and sweep history.


### PR DESCRIPTION
Closes #40.

Adds a small disambiguation note to `wiki/Projects.md` recording the **Cloud Agent Enablement** board (#11) location and pointing readers to the canonical audit row in `wiki/Boards.md`.

## Context

Issue #40 predates the terminology split (PR #98), which moved the GitHub Projects v2 audit log from `wiki/Projects.md` → `wiki/Boards.md`. Board #11 was already documented there:

- Active boards table row #11 (title, scope, custom field `Source: config / docs / smoke-test`, seeded issues #32–#40, Option B linkage to board #10).
- 2026-04-26 "create Cloud Agent Enablement board (#11)" sweep entry.

All ACs from #40 are met by that existing content. This PR closes the loop on the file referenced in the issue (`wiki/Projects.md`) so any future reader landing there sees an explicit pointer.

## Acceptance criteria

- [x] Add a new row/section for the project under the existing schema — recorded in `wiki/Boards.md` Active boards table (board #11) and the 2026-04-26 sweep log.
- [x] Include project number, title, scope, custom fields (`Source`: config / docs / smoke-test), seeded issue range (#32–#40) — all present on the #11 row.
- [x] Note linkage: complementary to project #10 via Option B manual handoff using the `agent-task` label — captured both on the #11 row and in this new Projects.md note.

## Tested

- `wiki/Projects.md` renders cleanly; only a 4-line additive section.
- No site/HTML changes — no need to run lychee or visual snapshots.
