### PR TITLE
chore: advance wiki-sync cursor to e276789 (first live run)

### DIFF
--- a/.copilot-tracking/wiki-sync-state.json
+++ b/.copilot-tracking/wiki-sync-state.json
@@ -1,14 +1,10 @@
 {
   "$schema": "./wiki-sync-state.schema.json",
-  "lastProcessedSha": "bb5aa4c62c78faaa2b466ad8f16464cb98fb5a64",
-  "lastRunAt": "2026-04-27T12:25:39Z",
+  "lastProcessedSha": "e276789e53c1cb243491916f05624436ec2f88a6",
+  "lastRunAt": "2026-04-27T13:50:00Z",
   "lastBatchSummary": {
-    "filed": [],
+    "filed": [169, 171, 174, 176, 177],
     "deferred": [],
     "cancelled": []
-  },
-  "_seed": {
-    "note": "Initial seed committed with PR for issue #144. The wiki-sync agent (issue #143) has not yet run; this SHA marks the baseline from which the first delta will be computed.",
-    "issue": "https://github.com/marcusjacobson/portfolio/issues/144"
   }
 }


### PR DESCRIPTION
Advances the wiki-sync state cursor from `bb5aa4c` (seed) to `e276789` after the first live `/wiki-sync-run` against `main`.

## Batch summary

- **Filed:** #169, #171, #174, #176, #177 (placed on board #16, Status=Todo, Phase=Maintenance, Priority=p3)
- **Deferred:** none
- **Cancelled:** none
- **Suppressed (dedupe):** 0
- **Out-of-routing surfaced:** README.md, .copilot-tracking/README.md, .copilot-tracking/wiki-sync-state.schema.json, .gitignore (no row in routing table v1; manual routing if needed)

Duplicates from parallel intake sessions (#170, #172, #173, #175, #178) were closed as 'not planned' with pointers to canonical issues.

Routing table version: v1.

Refs: #147 (first dry-run acceptance test).