### PR TITLE
boards-worker: close Wiki & Build-Docs Automation session

### DIFF
--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -37,6 +37,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #136 Todo → In Progress at 2026-04-27
   - #136 In Progress → Done — PR #151, merge `6223514`
   - #138 Todo → In Progress at 2026-04-27
+  - #138 In Progress → Done — PR #152, merge `47b0c60`
+  - #139 Todo → In Progress at 2026-04-27
 - **Outcome:** _(in flight)_
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -45,6 +45,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #137 unblocked — boards-worker rebased `feat/137-wiki-prompts-page` onto main, hand-merged Sections list (Agents/Prompts/Workflows coexist); #155 auto-closed
   - #137 In Progress → Done — PR #154, merge `e706f0d`
   - #140 Todo → In Progress at 2026-04-27
+  - #140 In Progress → Done — PR #156, merge `56d5cb9`
+  - #141 Todo → In Progress at 2026-04-27
 - **Outcome:** Batch 2 halted at #137. Phase 1 partial (Agents/Workflows/Repo-Architecture done; Prompts/Deployment-Rules/Home-index pending). Blocker issue #155 must clear before #137/#140/#141 proceed.
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -57,7 +57,11 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #143 Todo → In Progress → Done — PR #161, merge `d66ae5f`
   - #145 Todo → In Progress → Done — PR #162, merge `47b1cba`
   - #146 Todo → In Progress → Done — PR #163, merge `2a7eb42`
-- **Outcome:** Phase 1 Structure complete (6/6) and Phase 2 Agent complete (5/5 — state schema #144, request-intake ext #148, board-planner ext #149, wiki-sync agent design #143, /wiki-sync-run prompt #145). Phase 3 Automation: weekly cron #146 landed; #147 first dry-run remains. One mid-batch blocker (#155, wiki/Home.md Sections-list conflict) auto-closed via PR #154 rebase. Awaiting next batch instruction or session close.
+  - #142 Todo → In Progress → Done — PR #164, merge `94ce9eb`
+  - #30  Todo → In Progress → Done — PR #165, merge `69ee4f1`
+  - #37  Todo → In Progress → Done — PR #166, merge `73b6629`
+  - #147 deferred — operational dry-run requires interactive `/wiki-sync-run`; not an issue-resolver code task
+- **Outcome:** Phase 1 Structure (6/6) and Phase 2 Agent (5/5) complete. Phase 3 Automation: cron #146 landed; #147 dry-run deferred to user. Phase 4 Maintenance: label persistence #142 landed. Rehomed: #30 (linkedin-sync docs), #37 (local-vs-hosted agent map) landed; #38 and #40 remain. Awaiting next batch instruction or session close.
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)
 

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -60,8 +60,10 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #142 Todo → In Progress → Done — PR #164, merge `94ce9eb`
   - #30  Todo → In Progress → Done — PR #165, merge `69ee4f1`
   - #37  Todo → In Progress → Done — PR #166, merge `73b6629`
+  - #38  Todo → In Progress → Done — PR #167, merge `fdc7939`
+  - #40  Todo → In Progress → Done — PR #168, merge `e276789`
   - #147 deferred — operational dry-run requires interactive `/wiki-sync-run`; not an issue-resolver code task
-- **Outcome:** Phase 1 Structure (6/6) and Phase 2 Agent (5/5) complete. Phase 3 Automation: cron #146 landed; #147 dry-run deferred to user. Phase 4 Maintenance: label persistence #142 landed. Rehomed: #30 (linkedin-sync docs), #37 (local-vs-hosted agent map) landed; #38 and #40 remain. Awaiting next batch instruction or session close.
+- **Outcome:** Phase 1 Structure (6/6), Phase 2 Agent (5/5), Phase 4 Maintenance (1/1), and rehomed (4/4) complete. Phase 3 Automation: cron #146 landed; only #147 dry-run remains (deferred to interactive run by user). Board #16: 17 Done, 1 Todo. Session ready to close.
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)
 

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -42,6 +42,9 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #139 In Progress → Done — PR #153, merge `b574752`
   - #137 Todo → In Progress at 2026-04-27
   - #137 stays In progress — blocker: merge conflict in wiki/Home.md between PR #154 and main's recently-merged Sections list updates; tracked as p0 issue #155
+  - #137 unblocked — boards-worker rebased `feat/137-wiki-prompts-page` onto main, hand-merged Sections list (Agents/Prompts/Workflows coexist); #155 auto-closed
+  - #137 In Progress → Done — PR #154, merge `e706f0d`
+  - #140 Todo → In Progress at 2026-04-27
 - **Outcome:** Batch 2 halted at #137. Phase 1 partial (Agents/Workflows/Repo-Architecture done; Prompts/Deployment-Rules/Home-index pending). Blocker issue #155 must clear before #137/#140/#141 proceed.
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -49,6 +49,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #141 Todo → In Progress at 2026-04-27
   - #141 In Progress → Done — PR #157, merge `bb5aa4c`
   - #144 Todo → In Progress at 2026-04-27
+  - #144 In Progress → Done — PR #158, merge `7ae42c5`
+  - #148 Todo → In Progress at 2026-04-27
 - **Outcome:** Phase 1 Structure complete (6/6) — Agents, Workflows, Repo-Architecture, Prompts, Deployment-Rules, Home build-mechanics index all published. One mid-batch blocker (#155, wiki/Home.md Sections-list conflict) auto-closed via PR #154 rebase. Awaiting next batch instruction or session close.
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -40,6 +40,7 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #138 In Progress → Done — PR #152, merge `47b0c60`
   - #139 Todo → In Progress at 2026-04-27
   - #139 In Progress → Done — PR #153, merge `b574752`
+  - #137 Todo → In Progress at 2026-04-27
 - **Outcome:** Batch 1 complete (3/3) — wiki structure pages Agents/Workflows/Repo-Architecture published; awaiting next batch instruction or session close.
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -33,7 +33,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 - **Project node id:** `PVT_kwHOBvMdD84BV27q`
 - **Status field id:** `PVTSSF_lAHOBvMdD84BV27qzhRPoko`
 - **Schema mutations applied:** _(none — board #16 schema unchanged for this run)_
-- **Per-issue transitions:** _(populated as work proceeds)_
+- **Per-issue transitions:**
+  - #136 Todo → In Progress at 2026-04-27
 - **Outcome:** _(in flight)_
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -47,7 +47,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #140 Todo → In Progress at 2026-04-27
   - #140 In Progress → Done — PR #156, merge `56d5cb9`
   - #141 Todo → In Progress at 2026-04-27
-- **Outcome:** Batch 2 halted at #137. Phase 1 partial (Agents/Workflows/Repo-Architecture done; Prompts/Deployment-Rules/Home-index pending). Blocker issue #155 must clear before #137/#140/#141 proceed.
+  - #141 In Progress → Done — PR #157, merge `bb5aa4c`
+- **Outcome:** Phase 1 Structure complete (6/6) — Agents, Workflows, Repo-Architecture, Prompts, Deployment-Rules, Home build-mechanics index all published. One mid-batch blocker (#155, wiki/Home.md Sections-list conflict) auto-closed via PR #154 rebase. Awaiting next batch instruction or session close.
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)
 

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -24,6 +24,18 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 
 ## Sweep log
 
+### 2026-04-27 — boards-worker session: Wiki & Build-Docs Automation (#16)
+
+- **Branch:** `boards-worker/wiki-build-docs-20260427-0424` — PR _(opened at session close)_
+- **Operator:** boards-worker agent
+- **Queue at start (Todo, 18 items):** #30, #37, #38, #40, #136, #137, #138, #139, #140, #141, #142, #143, #144, #145, #146, #147, #148, #149
+- **Status field options captured:** Todo=`f75ad846`, In Progress=`47fc9ee4`, Done=`98236657` (no In-review-style option — per the alias table in `boards-worker.agent.md`, on-failure items stay at In Progress and the blocker is audit-logged)
+- **Project node id:** `PVT_kwHOBvMdD84BV27q`
+- **Status field id:** `PVTSSF_lAHOBvMdD84BV27qzhRPoko`
+- **Schema mutations applied:** _(none — board #16 schema unchanged for this run)_
+- **Per-issue transitions:** _(populated as work proceeds)_
+- **Outcome:** _(in flight)_
+
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)
 
 - **Branch:** `boards-worker/maturity-20260426-2120` — PR _(opened at session close)_

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -41,7 +41,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #139 Todo → In Progress at 2026-04-27
   - #139 In Progress → Done — PR #153, merge `b574752`
   - #137 Todo → In Progress at 2026-04-27
-- **Outcome:** Batch 1 complete (3/3) — wiki structure pages Agents/Workflows/Repo-Architecture published; awaiting next batch instruction or session close.
+  - #137 stays In progress — blocker: merge conflict in wiki/Home.md between PR #154 and main's recently-merged Sections list updates; tracked as p0 issue #155
+- **Outcome:** Batch 2 halted at #137. Phase 1 partial (Agents/Workflows/Repo-Architecture done; Prompts/Deployment-Rules/Home-index pending). Blocker issue #155 must clear before #137/#140/#141 proceed.
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)
 

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -53,7 +53,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #148 Todo → In Progress at 2026-04-27
   - #148 In Progress → Done — PR #159, merge `0216b0f`
   - #149 Todo → In Progress at 2026-04-27
-- **Outcome:** Phase 1 Structure complete (6/6) — Agents, Workflows, Repo-Architecture, Prompts, Deployment-Rules, Home build-mechanics index all published. One mid-batch blocker (#155, wiki/Home.md Sections-list conflict) auto-closed via PR #154 rebase. Awaiting next batch instruction or session close.
+  - #149 In Progress → Done — PR #160, merge `87d51c2`
+- **Outcome:** Phase 1 Structure complete (6/6) and Phase 2 Agent prerequisites complete (3/3 — state schema #144, request-intake ext #148, board-planner ext #149). #143 (agent design) and #145 (invocation prompt) now unblocked. One mid-batch blocker (#155, wiki/Home.md Sections-list conflict) auto-closed via PR #154 rebase. Awaiting next batch instruction or session close.
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)
 

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -59,11 +59,12 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #146 Todo → In Progress → Done — PR #163, merge `2a7eb42`
   - #142 Todo → In Progress → Done — PR #164, merge `94ce9eb`
   - #30  Todo → In Progress → Done — PR #165, merge `69ee4f1`
-  - #37  Todo → In Progress → Done — PR #166, merge `73b6629`
   - #38  Todo → In Progress → Done — PR #167, merge `fdc7939`
   - #40  Todo → In Progress → Done — PR #168, merge `e276789`
-  - #147 deferred — operational dry-run requires interactive `/wiki-sync-run`; not an issue-resolver code task
-- **Outcome:** Phase 1 Structure (6/6), Phase 2 Agent (5/5), Phase 4 Maintenance (1/1), and rehomed (4/4) complete. Phase 3 Automation: cron #146 landed; only #147 dry-run remains (deferred to interactive run by user). Board #16: 17 Done, 1 Todo. Session ready to close.
+  - #147 Todo → In Progress (live `/wiki-sync-run` against `main`)
+  - #147 In Progress → Done — closed COMPLETED after first live wiki-sync run; cursor PR #179, merge `ce55466`
+- **Wiki-sync first live run:** Cursor `bb5aa4c` → `e276789`. Filed: #169 (Prompts), #171 (Projects/Home verify), #174 (Repo-Architecture), #176 (Workflows), #177 (Agents) — all on board #16 with Status=Todo, Phase=Maintenance, Priority=p3. Closed as duplicates from parallel-intake artifact: #170, #172, #173, #175, #178. Out-of-routing surfaced (5 paths) flagged for routing-table v2 follow-up.
+- **Outcome:** Phase 1 Structure (6/6), Phase 2 Agent (5/5), Phase 3 Automation (2/2 — cron #146, dry-run #147), Phase 4 Maintenance (1/1), and rehomed (4/4) complete. Original 18 Todo all resolved; 5 follow-up wiki-content issues now Todo on board #16 from the live run. Session closed.
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)
 

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -51,6 +51,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #144 Todo → In Progress at 2026-04-27
   - #144 In Progress → Done — PR #158, merge `7ae42c5`
   - #148 Todo → In Progress at 2026-04-27
+  - #148 In Progress → Done — PR #159, merge `0216b0f`
+  - #149 Todo → In Progress at 2026-04-27
 - **Outcome:** Phase 1 Structure complete (6/6) — Agents, Workflows, Repo-Architecture, Prompts, Deployment-Rules, Home build-mechanics index all published. One mid-batch blocker (#155, wiki/Home.md Sections-list conflict) auto-closed via PR #154 rebase. Awaiting next batch instruction or session close.
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -35,6 +35,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 - **Schema mutations applied:** _(none — board #16 schema unchanged for this run)_
 - **Per-issue transitions:**
   - #136 Todo → In Progress at 2026-04-27
+  - #136 In Progress → Done — PR #151, merge `6223514`
+  - #138 Todo → In Progress at 2026-04-27
 - **Outcome:** _(in flight)_
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -39,7 +39,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #138 Todo → In Progress at 2026-04-27
   - #138 In Progress → Done — PR #152, merge `47b0c60`
   - #139 Todo → In Progress at 2026-04-27
-- **Outcome:** _(in flight)_
+  - #139 In Progress → Done — PR #153, merge `b574752`
+- **Outcome:** Batch 1 complete (3/3) — wiki structure pages Agents/Workflows/Repo-Architecture published; awaiting next batch instruction or session close.
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)
 

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -54,7 +54,10 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #148 In Progress → Done — PR #159, merge `0216b0f`
   - #149 Todo → In Progress at 2026-04-27
   - #149 In Progress → Done — PR #160, merge `87d51c2`
-- **Outcome:** Phase 1 Structure complete (6/6) and Phase 2 Agent prerequisites complete (3/3 — state schema #144, request-intake ext #148, board-planner ext #149). #143 (agent design) and #145 (invocation prompt) now unblocked. One mid-batch blocker (#155, wiki/Home.md Sections-list conflict) auto-closed via PR #154 rebase. Awaiting next batch instruction or session close.
+  - #143 Todo → In Progress → Done — PR #161, merge `d66ae5f`
+  - #145 Todo → In Progress → Done — PR #162, merge `47b1cba`
+  - #146 Todo → In Progress → Done — PR #163, merge `2a7eb42`
+- **Outcome:** Phase 1 Structure complete (6/6) and Phase 2 Agent complete (5/5 — state schema #144, request-intake ext #148, board-planner ext #149, wiki-sync agent design #143, /wiki-sync-run prompt #145). Phase 3 Automation: weekly cron #146 landed; #147 first dry-run remains. One mid-batch blocker (#155, wiki/Home.md Sections-list conflict) auto-closed via PR #154 rebase. Awaiting next batch instruction or session close.
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)
 

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -48,6 +48,7 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #140 In Progress → Done — PR #156, merge `56d5cb9`
   - #141 Todo → In Progress at 2026-04-27
   - #141 In Progress → Done — PR #157, merge `bb5aa4c`
+  - #144 Todo → In Progress at 2026-04-27
 - **Outcome:** Phase 1 Structure complete (6/6) — Agents, Workflows, Repo-Architecture, Prompts, Deployment-Rules, Home build-mechanics index all published. One mid-batch blocker (#155, wiki/Home.md Sections-list conflict) auto-closed via PR #154 rebase. Awaiting next batch instruction or session close.
 
 ### 2026-04-26 — boards-worker session: Portfolio Maturity (#15)


### PR DESCRIPTION
Closes the **boards-worker session** for board #16 ([Wiki & Build-Docs Automation](https://github.com/users/marcusjacobson/projects/16)). This PR contains only the wiki/Boards.md sweep-log entries — every code/content change landed via its own per-issue PR against `main` during the session.

## Session summary

- **Branch:** `boards-worker/wiki-build-docs-20260427-0424`
- **Operator:** `@boards-worker`
- **Queue at start:** 18 Todo items
- **Resolved this session:** 18/18 (15 via `@issue-resolver`, 1 via live wiki-sync acceptance test, plus 1 mid-session blocker)

### Phase tally

- Phase 1 Structure (6/6): #136, #137, #138, #139, #140, #141
- Phase 2 Agent (5/5): #143, #144, #145, #148, #149
- Phase 3 Automation (2/2): #146 (weekly cron), #147 (first live dry-run)
- Phase 4 Maintenance (1/1): #142
- Rehomed (4/4): #30, #37, #38, #40

### Mid-session blocker

- #155 — wiki/Home.md Sections-list conflict during PR #154; auto-resolved via rebase + force-push.

### Wiki-sync first live run (#147)

- Cursor advanced `bb5aa4c` → `e276789` via PR #179
- 5 follow-up issues filed: #169, #171, #174, #176, #177 (all placed on board #16, Status=Todo, Phase=Maintenance, Priority=p3)
- 5 duplicates closed (parallel-intake artifact): #170, #172, #173, #175, #178
- 5 paths flagged out-of-routing for routing-table v2 follow-up

### Process finding

Parallel `@request-intake` calls from a single `file all` decision produced 5 duplicate issues — each parallel session ran dedupe before the others' issues existed. Recommend updating `@wiki-sync` step 8 (or the orchestrator) to serialize handoffs.

## Files changed

Only `wiki/Boards.md`. The wiki-sync state file edit landed via its own PR (#179) per the wiki-sync agent contract.
