### PR TITLE
Bake issue+branch+PR workflow into @repo-cleanup

### DIFF
--- a/.github/agents/repo-cleanup.agent.md
+++ b/.github/agents/repo-cleanup.agent.md
@@ -75,13 +75,17 @@ Before discovery:
      --body 'Tracking issue for an interactive @repo-cleanup sweep. Items removed and remediations applied will be summarised in the linked PR.'
    ```
    Capture the issue number as `<N>`.
-3. **Create a branch** from `main`:
+3. **Place the issue on a board.** Hand the issue number to `@board-planner` in *wiki-sync batch sweep* style (a single-issue batch). Default routing for cleanup sweeps:
+   - If a `Repo Hygiene` board (or similar) already exists, add the issue there.
+   - Otherwise, propose adding it to **#15 Portfolio Maturity Roadmap** under `source:repo-cleanup` (or asking the user whether to spin up a dedicated board if cleanup work is becoming recurring).
+   - Wait for `@board-planner`'s diff block and the user's approval before any `gh project item-add` runs. Cleanup must not silently land on a board.
+4. **Create a branch** from `main`:
    ```pwsh
    git switch main
    git pull --ff-only
    git switch -c chore/<N>-repo-cleanup-sweep
    ```
-4. Echo the issue URL and branch name back to the user, then proceed to step 1.
+5. Echo the issue URL, board placement, and branch name back to the user, then proceed to step 1.
 
 If the user is already on a non-`main` branch when invoking the agent, ask whether to (a) reuse that branch, or (b) stash and create a fresh branch. Default to (b) when the existing branch has unrelated staged/uncommitted changes.
 

--- a/.github/agents/repo-cleanup.agent.md
+++ b/.github/agents/repo-cleanup.agent.md
@@ -60,6 +60,31 @@ If you find a candidate that doesn't fit any class above, surface it under a sep
 
 ## Workflow
 
+### 0. Open an issue and branch before touching anything
+
+This repo's convention (see `.github/copilot-instructions.md`) is **issue + branch + PR for every change**. Cleanup sweeps follow the same rules: nothing — no removals, no `.cleanupignore` edits, no `.gitignore` edits — happens on `main` directly.
+
+Before discovery:
+
+1. **Confirm not on `main`.** Run `git rev-parse --abbrev-ref HEAD`. If the result is `main`, do not proceed to discovery yet.
+2. **File a tracking issue** (skipping `@request-intake` per the mid-flow carveout — this is the agent's own scoped workflow, not a new feature request):
+   ```pwsh
+   gh issue create `
+     --title 'Repo cleanup sweep — <YYYY-MM-DD>' `
+     --label 'chore,area:workflow,priority:p3' `
+     --body 'Tracking issue for an interactive @repo-cleanup sweep. Items removed and remediations applied will be summarised in the linked PR.'
+   ```
+   Capture the issue number as `<N>`.
+3. **Create a branch** from `main`:
+   ```pwsh
+   git switch main
+   git pull --ff-only
+   git switch -c chore/<N>-repo-cleanup-sweep
+   ```
+4. Echo the issue URL and branch name back to the user, then proceed to step 1.
+
+If the user is already on a non-`main` branch when invoking the agent, ask whether to (a) reuse that branch, or (b) stash and create a fresh branch. Default to (b) when the existing branch has unrelated staged/uncommitted changes.
+
 ### 1. Prepare
 
 Run these in parallel:
@@ -151,11 +176,37 @@ Skipped (<s>):
   ...
 
 Branch:   <current branch>
+Issue:    #<N>
 Diff:     git diff --stat
-Next:     run `git status` to confirm; commit remediation file changes if any.
 ```
 
-If remediation files (`.gitignore`, `.cleanupignore`, in-file markers) were modified, the user commits and PRs them like any other change. This agent does not commit on the user's behalf.
+### 7. Commit, push, and open a PR
+
+If any remediation files (`.gitignore`, `.cleanupignore`, in-file `cleanup:keep` markers, renames) were modified, **or** any tracked files were removed during the walk:
+
+1. Stage and commit, referencing the tracking issue from step 0:
+   ```pwsh
+   git add -A
+   git commit -m 'Repo cleanup sweep — <m> removed, <k> kept with remediation' `
+              -m 'Refs #<N>. Removed: <short list>. Kept with remediation: <short list>.'
+   ```
+2. Push the branch:
+   ```pwsh
+   git push -u origin chore/<N>-repo-cleanup-sweep
+   ```
+3. Open a PR linked to the issue:
+   ```pwsh
+   gh pr create `
+     --base main `
+     --title 'Repo cleanup sweep — closes #<N>' `
+     --body  '<paste the step 6 report block here>' `
+     --label 'chore,area:workflow'
+   ```
+4. Watch checks (`gh pr checks --watch`). When green, hand control back to the user — **do not auto-merge.** The user squash-merges per repo policy.
+
+If nothing was changed during the walk (all `skip`s, or `quit` before the first action), close the tracking issue with a comment summarising why and skip the PR.
+
+This agent never pushes directly to `main`, never force-pushes, and never deletes remote branches.
 
 ## Output discipline
 

--- a/.github/prompts/repo-cleanup.prompt.md
+++ b/.github/prompts/repo-cleanup.prompt.md
@@ -12,15 +12,18 @@ You are running the cleanup workflow defined in [`.github/agents/repo-cleanup.ag
 ## Steps
 
 1. **Engage `@repo-cleanup`.** Apply any `--scope=`, `--age=`, or `--no-branches` argument the user provided. Default `--age=14` and include local merged branches.
-2. **Run the prepare phase** (the parallel discovery commands listed in the agent file).
-3. **Print the one-line summary and the FIRST candidate only.** Use the per-item block shape from step 3 of the agent file (`[1/<N>] <class> <path>` with `reason:`, `action on remove:`, `remediation on keep:`). Do not print item 2 in the same turn.
-4. **Walk one item at a time.** Wait for `remove`, `keep`, `skip`, `show all`, or `quit` between every item. Bare verbs apply to the currently-prompted item. Echo destructive commands before running them. Always present exactly one candidate per assistant turn.
-5. **Apply remediations on `keep`** using the per-class table in the agent file (`.gitignore`, `.cleanupignore`, in-file `# cleanup:keep` marker, or rename).
-6. **Print the final report** when the user types `quit` or every item has been answered.
+2. **Open issue + branch first** (step 0 of the agent file). File a `chore,area:workflow,priority:p3` tracking issue, then create `chore/<N>-repo-cleanup-sweep` from `main`. Never run discovery or any mutation while still on `main`.
+3. **Run the prepare phase** (the parallel discovery commands listed in the agent file).
+4. **Print the one-line summary and the FIRST candidate only.** Use the per-item block shape from step 3 of the agent file (`[1/<N>] <class> <path>` with `reason:`, `action on remove:`, `remediation on keep:`). Do not print item 2 in the same turn.
+5. **Walk one item at a time.** Wait for `remove`, `keep`, `skip`, `show all`, or `quit` between every item. Bare verbs apply to the currently-prompted item. Echo destructive commands before running them. Always present exactly one candidate per assistant turn.
+6. **Apply remediations on `keep`** using the per-class table in the agent file (`.gitignore`, `.cleanupignore`, in-file `# cleanup:keep` marker, or rename).
+7. **Print the final report** when the user types `quit` or every item has been answered.
+8. **Commit, push, and open a PR** linked to the tracking issue (step 7 of the agent file). Never auto-merge; hand control back to the user once checks are green.
 
 ## Constraints
 
 - Read-only by default. No deletes, no branch removals, no file edits without per-item user approval in the same turn.
+- Never run discovery or mutations on `main`. Always operate from `chore/<N>-repo-cleanup-sweep`.
 - Never push branch deletes to `origin`; local-only `git branch -d`.
-- Never commit on the user's behalf. The user reviews the remediation diff and commits manually.
+- Commits and the closing PR happen at the end (step 8) under the tracking issue. Never auto-merge.
 - If a candidate is tracked in git and not on a known stale-output path, escalate before proposing removal.

--- a/.github/prompts/repo-cleanup.prompt.md
+++ b/.github/prompts/repo-cleanup.prompt.md
@@ -12,7 +12,7 @@ You are running the cleanup workflow defined in [`.github/agents/repo-cleanup.ag
 ## Steps
 
 1. **Engage `@repo-cleanup`.** Apply any `--scope=`, `--age=`, or `--no-branches` argument the user provided. Default `--age=14` and include local merged branches.
-2. **Open issue + branch first** (step 0 of the agent file). File a `chore,area:workflow,priority:p3` tracking issue, then create `chore/<N>-repo-cleanup-sweep` from `main`. Never run discovery or any mutation while still on `main`.
+2. **Open issue + place on a board + branch first** (step 0 of the agent file). File a `chore,area:workflow,priority:p3` tracking issue, hand it to `@board-planner` for placement (default: a `Repo Hygiene`-style board if one exists, else propose **#15 Portfolio Maturity Roadmap** under `source:repo-cleanup`), then create `chore/<N>-repo-cleanup-sweep` from `main`. Never run discovery or any mutation while still on `main`.
 3. **Run the prepare phase** (the parallel discovery commands listed in the agent file).
 4. **Print the one-line summary and the FIRST candidate only.** Use the per-item block shape from step 3 of the agent file (`[1/<N>] <class> <path>` with `reason:`, `action on remove:`, `remediation on keep:`). Do not print item 2 in the same turn.
 5. **Walk one item at a time.** Wait for `remove`, `keep`, `skip`, `show all`, or `quit` between every item. Bare verbs apply to the currently-prompted item. Echo destructive commands before running them. Always present exactly one candidate per assistant turn.


### PR DESCRIPTION
Closes #186. Adds a step 0 prelude (refuses to operate on main; files a chore/area:workflow/priority:p3 tracking issue; creates chore/<N>-repo-cleanup-sweep) and a step 7 closeout (commits remediations referencing the issue, pushes, opens a labelled PR; never auto-merges). Mirrors the new shape in /repo-cleanup. Mid-flow refinement of #183 / PR #184; intake skipped per the mid-flow carveout.