### PR TITLE
Repo cleanup sweep (resumed)

### DIFF
--- a/.cleanupignore
+++ b/.cleanupignore
@@ -1,0 +1,7 @@
+# Paths and branches the @repo-cleanup agent should skip on future runs.
+# Format:
+#   <path-or-filename>           # one entry per line; matched literally
+#   branches:
+#     <branch-name>              # list under the branches: header
+
+test-results/


### PR DESCRIPTION
Closes #188.

## Summary

Sweep walked 20 candidates (originally 26; first 5 resolved before #186 / #187 baked the new workflow into the agent).

| Class | Item | Outcome |
|---|---|---|
| A | `test-results/` | keep (added to .cleanupignore) |
| B | `staging-inbox/certification_strategy_v1.html` | remove (gitignored) |
| B | `staging-inbox/landing_page_v1.html` | remove (gitignored) |
| B | `staging-inbox/ms_security_compass_v20.html` | remove (gitignored) |
| B | `staging-inbox/ms_security_projects_roadmap_v1.html` | remove (gitignored) |
| B | `staging-inbox/GITHUB_LINKING.md` | remove (gitignored) |
| B | `staging-inbox/GITHUB_PAGES_PUBLISHING.md` | remove (gitignored) |
| B | `staging-inbox/ms_security_projects.html` | remove (gitignored) |
| B | `staging-inbox/ms_security_roles_v2.html` | remove (gitignored) |
| B | `staging-inbox/PORTFOLIO_MATURITY_ROADMAP_v2.md` | remove (gitignored) |
| B | `staging-inbox/SKILLS_CALIBRATION_GUIDE.md` | remove (gitignored) |
| B | `staging-inbox/skills_inventory_v1.html` | remove (gitignored) |
| C | 13 merged local branches | remove (local-only `git branch -D`) |

Only tracked diff is the new `.cleanupignore`. Tracking issue #188 on board #17 (Repo Hygiene).

Mid-flow continuation of #186 / #187; intake skipped per the standard mid-flow carveout.