### PR TITLE
Add agent:triage and triage:proposed labels (#195)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -71,10 +71,16 @@
 - name: agent:copilot-enablement
   color: 8957e5
   description: Tasks to enable and operate the GitHub Copilot cloud agent on this repo
+- name: agent:triage
+  color: 8957e5
+  description: Tasks for the @triage agent build or its findings
 
 # Lifecycle
 - name: needs-triage
   color: fef2c0
+- name: triage:proposed
+  color: fbca04
+  description: Triage agent has posted a proposal comment; awaiting user apply/dismiss
 - name: link-rot
   color: c5def5
   description: External link broke.


### PR DESCRIPTION
## Summary

Adds two new labels to the canonical manifest at `.github/labels.yml` and applies them to the repo via `scripts/gh/sync-labels.ps1`:

- `agent:triage` (`#8957e5`) — matches the existing `agent:*` family color.
- `triage:proposed` (`#fbca04`) — distinct yellow signal for "agent has posted a proposal, awaiting user apply/dismiss".

Closes #195.

## Verification

```text
$ pwsh -File scripts/gh/sync-labels.ps1
...
CREATE agent:triage
CREATE triage:proposed
```

```text
$ gh label list --search "triage"
agent:triage      Tasks for the @triage agent build or its findings
triage:proposed   Triage agent has posted a proposal comment; awaiting user apply/dismiss
needs-triage     (existing)
```

## Acceptance criteria

- [x] `agent:triage` label exists with description and color matching `agent:*` family (`#8957e5`).
- [x] `triage:proposed` label exists with description and a distinct color (`#fbca04`).
- [x] Both labels added to `.github/labels.yml`.
- [ ] `wiki/Repo-Architecture.md` label table updated — **N/A**: that file does not currently contain a label table. No other wiki page enumerates labels either. If a label inventory page is desired later, file as a separate `area:wiki` task.

## Tested

- Manifest dry-run: only the two new labels show as `CREATE`, no churn on existing labels.
- Live sync: both labels visible on the repo via `gh label list`.

## Notes

Unblocks #191 (`@triage` agent build).
