### PR TITLE
chore: route cloud-triage tags to their boards via auto-add workflow (#215)

### DIFF
--- a/.github/workflows/tag-routing-autoadd.yml
+++ b/.github/workflows/tag-routing-autoadd.yml
@@ -1,0 +1,64 @@
+name: Tag-routing auto-add to boards
+
+# Routes issues labeled with a cloud-triage routing tag to the matching
+# Projects v2 board. Tag-to-board map (also documented in
+# .github/agents/triage.agent.md and consumed by the cloud /triage workflow):
+#
+#   compass        -> #9  Compass v-next
+#   certification  -> #2  Certification/Education Path
+#   linkedin       -> #10 LinkedIn / Portfolio Sync
+#   wiki           -> #16 Wiki & Build-Docs Automation
+#   maturity       -> #15 Portfolio Maturity
+#   project        -> #13 Microsoft Security Portfolio Roadmap
+#
+# `bug` -> #12 is handled by bug-autoadd.yml. `Board` (legacy) -> #13 is
+# handled by board-autoadd.yml. `needs-triage` -> #19 is handled by
+# triage-autoadd.yml. `source:*` -> #15 is handled by maturity-autoadd.yml.
+# This workflow covers the remaining six routing tags.
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: tag-routing-autoadd-${{ github.event.issue.number }}-${{ github.event.label.name || 'opened' }}
+  cancel-in-progress: false
+
+jobs:
+  add-to-project:
+    name: Route ${{ matrix.tag }} -> board #${{ matrix.project }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tag: compass
+            project: 9
+          - tag: certification
+            project: 2
+          - tag: linkedin
+            project: 10
+          - tag: wiki
+            project: 16
+          - tag: maturity
+            project: 15
+          - tag: project
+            project: 13
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == matrix.tag) ||
+      (github.event.action == 'opened' && contains(github.event.issue.labels.*.name, matrix.tag))
+    steps:
+      - name: Add issue to board #${{ matrix.project }}
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        with:
+          project-url: https://github.com/users/marcusjacobson/projects/${{ matrix.project }}
+          # Reuses the classic-PAT secret that already powers bug-autoadd.yml /
+          # board-autoadd.yml / maturity-autoadd.yml / triage-autoadd.yml.
+          # Project (board) scope on the same user-owned account covers all
+          # six destination boards. The default GITHUB_TOKEN cannot write to
+          # user-owned Projects v2 boards.
+          github-token: ${{ secrets.BUG_PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/tag-routing-autoadd.yml` — a single workflow with a `(tag, project)` matrix that routes the six new cloud-triage routing tags to their destination Projects v2 boards.

## Tag-to-board map

| Tag | Board |
|---|---|
| `compass` | #9 Compass v-next |
| `certification` | #2 Certification/Education Path |
| `linkedin` | #10 LinkedIn / Portfolio Sync |
| `wiki` | #16 Wiki & Build-Docs Automation |
| `maturity` | #15 Portfolio Maturity |
| `project` | #13 Microsoft Security Portfolio Roadmap |

The matrix shape keeps the map in one place; only the matching matrix job's `if` condition evaluates true on a given `labeled` event, so the workflow is fan-out idempotent.

## Why a new file (not an extension of an existing one)

The four existing `*-autoadd.yml` workflows (`bug-autoadd`, `board-autoadd`, `maturity-autoadd`, `triage-autoadd`) each route a different label-set to a different board. Folding the new six tags into any of them would mix concerns. A single `tag-routing-autoadd.yml` keeps the cloud `/triage` routing surface in one file, ready to extend if a new tag is added later (just add a row to the matrix).

## Acceptance criteria

- [x] Workflow listens on `issues: [opened, labeled]` and routes by tag-to-board map.
- [x] Map covers `compass` → #9, `certification` → #2, `linkedin` → #10, `wiki` → #16, `maturity` → #15, `project` → #13. (`bug` → #12 remains in `bug-autoadd.yml`.)
- [x] Pins `actions/add-to-project` to v1.0.2 SHA `244f685bbc3b7adfa8466e08b698b5577571133e`.
- [x] Reuses `BUG_PROJECT_TOKEN` classic-PAT secret (project scope).
- [x] `permissions:` block sets `contents: read` and `issues: read` only — no elevation.
- [ ] Smoke test: deferred to post-merge — a synthetic test issue cycled through each of the six tags, confirming the matching board picks it up before unlabel/close.
- [x] Idempotent: `actions/add-to-project` returns the existing item id if the issue is already on the board (verified pattern from `bug-autoadd.yml`).

Closes #215
