### PR TITLE
boards-worker session: Cloud Agent Enablement (2026-04-28 resume)

### DIFF
--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -26,6 +26,18 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 
 ## Sweep log
 
+### 2026-04-28 — boards-worker session: Cloud Agent Enablement (#11) — resume
+
+- **Branch:** `boards-worker/cloud-agent-enablement-resume-20260428-0734` — PR _(opened at session close)_
+- **Operator:** boards-worker agent
+- **Context:** Resume of the earlier 2026-04-28 session whose branch was cleaned up after #214 and #215 merged. Prior outcomes for continuity: #214 Todo → Done via PR #219 (merge `efe6606`); #215 Todo → Done via PR #220 (merge `983d74e`) plus YAML follow-up PR #221 (merge `47a9219`).
+- **Queue at start (Todo, scoped to caller's list):** #216, #217
+- **Status field options captured:** Source=Todo (`f75ad846`), In-flight=In Progress (`47fc9ee4`), In-review parking=_(none — using audit-log fallback per Status field handling)_, Done=Done (`98236657`)
+- **Schema mutations applied:** _(none)_
+- **Per-issue transitions:**
+  - _(populated as the batch runs)_
+- **Outcome:** _(populated at end of batch)_
+
 ### 2026-04-27 — recreate Triage Queue as board #19 (deleted #18)
 
 After the initial backfill of 9 issues onto board #18, the project's `items` GraphQL connection persistently returned `totalCount: 0` despite items existing (queryable from the issue side via `repository.issue.projectItems` and via direct node-id lookups, with `isArchived: false`). The web UI mirrored the broken connection (board displayed empty). A field-value mutation nudge did not unstick the index. Cross-board comparison confirmed boards #12/#15/#16 still returned correct item counts on the same query, so the corruption was scoped to #18 alone — consistent with a GitHub Projects v2 indexing incident around the time #18 was created and seeded.

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -37,7 +37,9 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 - **Per-issue transitions:**
   - #216 Todo → In Progress at 2026-04-28T07:35-07:00
   - #216 In Progress → Done — PR #222, merge `5cd2dbc`
-- **Outcome:** _(populated at end of batch)_
+  - #217 Todo → In Progress at 2026-04-28T08:05-07:00
+  - #217 In Progress → Done — PR #223, merge `7739bba`
+- **Outcome:** Clean drain — both queued items merged. 2/2 worked, 0 blocked. Smoke-test AC on #217 left unchecked by design (deferred to the existing #39 end-to-end smoke-test slot, which is the natural integration point now that #214 + #215 + #216 + #217 have all landed).
 
 ### 2026-04-27 — recreate Triage Queue as board #19 (deleted #18)
 

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -36,6 +36,7 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 - **Schema mutations applied:** _(none)_
 - **Per-issue transitions:**
   - #216 Todo → In Progress at 2026-04-28T07:35-07:00
+  - #216 In Progress → Done — PR #222, merge `5cd2dbc`
 - **Outcome:** _(populated at end of batch)_
 
 ### 2026-04-27 — recreate Triage Queue as board #19 (deleted #18)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -35,7 +35,7 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 - **Status field options captured:** Source=Todo (`f75ad846`), In-flight=In Progress (`47fc9ee4`), In-review parking=_(none — using audit-log fallback per Status field handling)_, Done=Done (`98236657`)
 - **Schema mutations applied:** _(none)_
 - **Per-issue transitions:**
-  - _(populated as the batch runs)_
+  - #216 Todo → In Progress at 2026-04-28T07:35-07:00
 - **Outcome:** _(populated at end of batch)_
 
 ### 2026-04-27 — recreate Triage Queue as board #19 (deleted #18)


### PR DESCRIPTION
Closes the resumed boards-worker session on board [#11 Cloud Agent Enablement](https://github.com/users/marcusjacobson/projects/11).

Body is the audit-log entry verbatim — see `wiki/Boards.md` for the canonical record.

---

### 2026-04-28 — boards-worker session: Cloud Agent Enablement (#11) — resume

- **Branch:** `boards-worker/cloud-agent-enablement-resume-20260428-0734` — this PR
- **Operator:** boards-worker agent
- **Context:** Resume of the earlier 2026-04-28 session whose branch was cleaned up after #214 and #215 merged. Prior outcomes for continuity: #214 Todo → Done via PR #219 (merge `efe6606`); #215 Todo → Done via PR #220 (merge `983d74e`) plus YAML follow-up PR #221 (merge `47a9219`).
- **Queue at start (Todo, scoped to caller's list):** #216, #217
- **Status field options captured:** Source=Todo (`f75ad846`), In-flight=In Progress (`47fc9ee4`), In-review parking=*(none — using audit-log fallback per Status field handling)*, Done=Done (`98236657`)
- **Schema mutations applied:** *(none)*
- **Per-issue transitions:**
  - #216 Todo → In Progress at 2026-04-28T07:35-07:00
  - #216 In Progress → Done — PR #222, merge `5cd2dbc`
  - #217 Todo → In Progress at 2026-04-28T08:05-07:00
  - #217 In Progress → Done — PR #223, merge `7739bba`
- **Outcome:** Clean drain — both queued items merged. 2/2 worked, 0 blocked. Smoke-test AC on #217 left unchecked by design (deferred to the existing #39 end-to-end smoke-test slot, which is the natural integration point now that #214 + #215 + #216 + #217 have all landed).
