### PR TITLE
fix(triage-respond): query suggestedActors at repository scope

### DIFF
--- a/.github/workflows/triage-respond.yml
+++ b/.github/workflows/triage-respond.yml
@@ -121,15 +121,15 @@ jobs:
           read -r -d '' ISSUE_QUERY <<'GRAPHQL' || true
           query($owner: String!, $name: String!, $number: Int!) {
             repository(owner: $owner, name: $name) {
+              suggestedActors(capabilities: [CAN_BE_ASSIGNED], first: 25) {
+                nodes {
+                  __typename
+                  ... on Bot { id login }
+                  ... on User { id login }
+                }
+              }
               issue(number: $number) {
                 id
-                suggestedActors(capabilities: [CAN_BE_ASSIGNED], first: 25) {
-                  nodes {
-                    __typename
-                    ... on Bot { id login }
-                    ... on User { id login }
-                  }
-                }
               }
             }
           }
@@ -142,7 +142,7 @@ jobs:
             -f query="$ISSUE_QUERY")
 
           ISSUE_ID=$(echo "$RESPONSE" | jq -r '.data.repository.issue.id')
-          COPILOT_ID=$(echo "$RESPONSE" | jq -r '.data.repository.issue.suggestedActors.nodes[] | select(.login == "copilot-swe-agent") | .id')
+          COPILOT_ID=$(echo "$RESPONSE" | jq -r '.data.repository.suggestedActors.nodes[] | select(.login == "copilot-swe-agent") | .id')
 
           if [ -z "$COPILOT_ID" ] || [ "$COPILOT_ID" = "null" ]; then
             echo "::error::copilot-swe-agent not found in suggestedActors. Is the cloud agent enabled on this repo?"


### PR DESCRIPTION
Closes #230.

## Summary

`suggestedActors` is a field on the `Repository` GraphQL type, not on `Issue`. The previous query nested it under `repository.issue { ... }`, causing every `/triage` reply that passed the job-level gate to fail with:

```ngh: Field 'suggestedActors' doesn't accept argument 'capabilities'
```

With the field at the wrong scope, the listener never resolved Copilot's actor id and never re-assigned `@copilot`, breaking the cloud `@triage` Mode 2 contract end-to-end.

## Change

Move `suggestedActors` to repository scope and update the jq selector from `.data.repository.issue.suggestedActors.nodes[]` to `.data.repository.suggestedActors.nodes[]`. `issue(number)` keeps its `id` field at the same query depth.

## Tested

- [x] YAML parses (no workflow validation errors)
- [ ] Live re-test on a `triage:proposed` issue once merged (covered by smoke test plan referenced from #228)