### PR TITLE
feat(agents): add repo-root AGENTS.md with cloud-agent routing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,7 @@ This is a static HTML portfolio site published to GitHub Pages. There is **no bu
 
 | Folder | Purpose |
 |--------|---------|
+| `AGENTS.md` (root) | Routing contract loaded by the hosted Copilot cloud agent on every run (label-keyed: `needs-triage` → triage Mode 2; `agent-task` → resolver). |
 | `.github/workflows/` | CI: deploy, previews, link-check, lint, visual regression, CodeQL, gitleaks, wiki sync |
 | `.github/instructions/` | Scoped Copilot guidance (auto-attaches by `applyTo`) |
 | `.github/prompts/` | Slash-command tasks (publish, secure review, staging, triage) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# AGENTS.md — guidance for the hosted Copilot cloud agent
+
+This file is loaded automatically by the GitHub Copilot cloud (coding) agent when it runs against this repository. Keep it brief; it is loaded into every agent run's context.
+
+For VS Code Copilot Chat conventions, the canonical source remains [.github/copilot-instructions.md](.github/copilot-instructions.md) and the path-scoped files under [.github/instructions/](.github/instructions/). This file summarizes — it does not duplicate.
+
+## What this repo is
+
+- Static HTML portfolio site published to GitHub Pages. **No build step** for the site.
+- Pages live at the repo root: `index.html`, `ms_security_compass.html`, `ms_security_roles.html`, `ms_security_projects.html`, `certification_strategy.html`, `skills_inventory.html`. Keep the filename scheme; no version suffixes.
+- Tooling layout, intake/triage flow, agent and prompt indexes: see [.github/copilot-instructions.md](.github/copilot-instructions.md).
+
+## Hard rules (do not break)
+
+- **Never push directly to `main`.** Always work on a branch and open a PR. Required checks must be green.
+- **Never edit `tests/visual/__snapshots__/` by hand.** Regenerate with `npm run test:visual:update`.
+- **Pin Action versions** in `.github/workflows/*.yml` (major tag minimum; SHA preferred for third-party).
+- **`permissions:` is required** on every workflow. Default to `contents: read` and elevate per job.
+- **No secrets, PATs, or personal data** in the repo. `gitleaks` runs on every PR.
+- All `<img>` tags need `alt` attributes (`htmlhint` enforces this).
+
+## Commands
+
+- Lint: `npm run lint` (runs `htmlhint` + `stylelint`).
+- Visual regression: `npm run test:visual` (update snapshots: `npm run test:visual:update`).
+- Link check: configured in `tests/lychee.toml`; runs in CI via `Link Check/lychee`.
+
+## Commit and PR style
+
+- Commit subject: imperative, ≤72 chars. Body explains *why* if non-obvious.
+- PR title: same style as commit subject.
+- PR description: summary, screenshots for visual changes, tested checklist.
+
+## Cloud-agent routing rules
+
+The hosted agent has no built-in router. These rules tell you which contract to follow based on issue labels.
+
+### `needs-triage` issues → run the triage agent (Mode 2), do **not** implement
+
+If you have been assigned to an issue carrying the `needs-triage` label:
+
+1. **Do not branch, do not implement, do not open a PR.**
+2. Read [.github/agents/triage.agent.md](.github/agents/triage.agent.md) and execute **Mode 2 — Cloud-comment mode**:
+   - Build the proposal (read the issue, discover context, choose a tag + priority + board home).
+   - Post the self-documenting proposal block as a single issue comment via `gh issue comment`. Include every reply command inline (`/triage <tag>`, `/triage <tag> p<0-3>`, `/triage dismiss …`, `/triage needs-info …`, `/triage cancel`).
+   - Add the `triage:proposed` label.
+   - Stop. Wait for the maintainer to reply.
+3. The `triage-respond.yml` workflow re-invokes you when the maintainer replies; follow the same agent file to apply or dismiss.
+
+### `agent-task` issues → resolver workflow (branch + PR)
+
+If you have been assigned to an issue carrying `agent-task` (and **not** `needs-triage`), follow the resolver flow: branch, implement, lint, commit, open one PR per task. One issue → one PR.
+
+### Anything else
+
+If neither label is present, comment on the issue explaining you can't tell which contract to use, and stop. Do not implement on speculation.
+
+## Budget note
+
+Expect roughly **one premium request per task**. If your first attempt fails:
+
+- Diagnose, then try a different approach.
+- **Do not retry the same approach more than twice.** If the second attempt fails the same way, post a comment on the issue explaining the blocker and stop. The maintainer will route the issue elsewhere or refine scope.
+
+## Index of agent files
+
+For the full list of specialized agents (request-intake, bug-intake, project-intake, issue-resolver, boards-worker, repo-ops, security-reviewer, publish-manager, repo-cleanup, maturity-scout, triage, wiki-sync, linkedin-sync, board-planner) see `.github/agents/` and the [Agents wiki page](wiki/Agents.md). Most are chat-mode only; `triage.agent.md` is the one with a documented cloud-comment mode.
+
+## Path-specific instruction files
+
+Scoped guidance auto-attaches by `applyTo` glob in VS Code; in cloud runs, read them on demand:
+
+- [.github/instructions/html-pages.instructions.md](.github/instructions/html-pages.instructions.md) — `*.html`
+- [.github/instructions/wiki-content.instructions.md](.github/instructions/wiki-content.instructions.md) — `wiki/**`
+- [.github/instructions/workflows.instructions.md](.github/instructions/workflows.instructions.md) — `.github/workflows/**`

--- a/tests/lychee.toml
+++ b/tests/lychee.toml
@@ -38,6 +38,8 @@ exclude = [
     "^https?://github\\.com/marcusjacobson/portfolio/blob/main/\\.github/agents/triage\\.agent\\.md",
     # LICENSE added in PR #226 — 404 until merged to main.
     "^https?://github\\.com/marcusjacobson/portfolio/blob/main/LICENSE$",
+    # AGENTS.md added in PR #232 — 404 until merged to main.
+    "^https?://github\\.com/marcusjacobson/portfolio/blob/main/AGENTS\\.md$",
     # LinkedIn returns 404 to unauthenticated bots (intermittent). Public profile is verified manually.
     "^https?://(www\\.)?linkedin\\.com/in/",
 ]

--- a/wiki/Agents.md
+++ b/wiki/Agents.md
@@ -81,6 +81,16 @@ It has two summon paths:
 
 The hosted agent is best at **file-scoped, one-shot tasks**: a typo fix, a single-page content tweak, a small refactor with a clear acceptance test. It is weakest at orchestration (multi-step board drains, cross-cutting refactors, anything that needs interactive design decisions) and at anything that depends on uncommitted local working-tree state.
 
+### Routing contract — `AGENTS.md`
+
+The hosted agent reads [`AGENTS.md`](https://github.com/marcusjacobson/portfolio/blob/main/AGENTS.md) at the repo root on every run (per [GitHub's docs](https://docs.github.com/en/copilot/tutorials/cloud-agent/get-the-best-results#adding-custom-instructions-to-your-repository)). That file is the **only** place the cloud agent's behavior is configured from this repo, and it carries the label-keyed routing rules:
+
+- **Issue carries `needs-triage`** — the hosted agent does **not** branch or implement. It loads [`.github/agents/triage.agent.md`](https://github.com/marcusjacobson/portfolio/blob/main/.github/agents/triage.agent.md) and runs **Mode 2 (cloud-comment)**: post the self-documenting proposal as a comment, add `triage:proposed`, then stop. The maintainer replies with `/triage <tag> [p<n>]`, `/triage dismiss …`, `/triage needs-info …`, or `/triage cancel`. The [`triage-respond.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/workflows/triage-respond.yml) workflow re-invokes the hosted agent on each reply so it can apply or dismiss.
+- **Issue carries `agent-task`** (and **not** `needs-triage`) — the hosted agent runs the resolver flow: branch, implement, lint, commit, one PR per task.
+- **Neither label** — the hosted agent comments that it can't tell which contract to use, and stops.
+
+A budget rule also applies: roughly one premium request per task; the agent must not retry the same approach more than twice. If the second attempt fails, it posts a blocker comment and hands the issue back to the maintainer.
+
 ### Local vs. hosted at a glance
 
 | Dimension | Local chat-mode agents | Hosted Copilot coding agent |
@@ -113,6 +123,7 @@ When in doubt, prefer the local chat-mode agents — they share state with your 
 
 ## See also
 
+- [`AGENTS.md`](https://github.com/marcusjacobson/portfolio/blob/main/AGENTS.md) — routing contract loaded by the hosted Copilot cloud agent on every run.
 - [`.github/agents/README.md`](https://github.com/marcusjacobson/portfolio/blob/main/.github/agents/README.md) — auto-generated index synced from each agent's `readme-summary:` frontmatter via the [`/sync-agent-prompt-readmes`](https://github.com/marcusjacobson/portfolio/blob/main/.github/prompts/sync-agent-prompt-readmes.prompt.md) prompt.
 - [`.github/prompts/README.md`](https://github.com/marcusjacobson/portfolio/blob/main/.github/prompts/README.md) — slash-command counterparts to these agents.
 - [`.github/copilot-instructions.md`](https://github.com/marcusjacobson/portfolio/blob/main/.github/copilot-instructions.md) — repo-wide rules every agent inherits.


### PR DESCRIPTION
## Summary

Authors a repo-root `AGENTS.md` (75 lines) that the hosted GitHub Copilot cloud agent loads on every run, plus documents the routing contract in `wiki/Agents.md` and surfaces `AGENTS.md` in the `.github/copilot-instructions.md` tooling table.

Closes #32. Closes #228.

## What changed

- **New file:** `AGENTS.md` at repo root.
- **Updated:** `wiki/Agents.md` \u2014 new *Routing contract* subsection under *Hosted cloud agent*, plus a `See also` entry.
- **Updated:** `.github/copilot-instructions.md` \u2014 `AGENTS.md` row added to the Tooling layout table.

## Routing rules encoded in `AGENTS.md`

| Issue carries | Hosted-agent action |
|---|---|
| `needs-triage` | Load [.github/agents/triage.agent.md](https://github.com/marcusjacobson/portfolio/blob/main/.github/agents/triage.agent.md) and run **Mode 2** (post self-documenting proposal comment, add `triage:proposed`, stop). **Do not** branch or open a PR. |
| `agent-task` (and not `needs-triage`) | Resolver flow: branch, implement, lint, commit, one PR per task. |
| Neither label | Comment that the contract is unclear, then stop. |

Plus a budget rule: ~1 premium request per task; do not retry the same approach more than twice.

## Why this fixes #228

#228 was the user-visible impact of the missing `AGENTS.md`: the hosted `@copilot` ran the resolver on `needs-triage` issues (#120 \u2192 PR #226, #132) instead of executing the `@triage` Mode 2 contract. The cloud agent has no built-in router \u2014 `AGENTS.md` is the only repo-controlled mechanism that switches its behavior on issue labels.

## Acceptance criteria (#32)

- [x] Create `AGENTS.md` at the repo root.
- [x] Summarizes (does not duplicate): no-build static site, page filename scheme, hard rules around snapshots and `main`, lint commands, commit/PR style.
- [x] Tells the cloud agent: only act on issues labeled `agent-task`; one PR per task.
- [x] Budget note: ~1 premium request per task; do not retry the same approach more than twice.
- [x] Links back to `.github/copilot-instructions.md` and the path-specific instruction files.
- [x] Under 100 lines (75).

## Acceptance criteria (#228)

- [x] When `@copilot` is assigned to an issue carrying `needs-triage`, the routing rule sends it to `triage.agent.md` Mode 2 (proposal comment + `triage:proposed` label, no PR).
- [x] When `@copilot` is assigned to an issue without `needs-triage`, the resolver behavior continues unchanged.
- [x] The routing mechanism is documented in `wiki/Agents.md`.

## Tested

- [x] Markdown renders cleanly.
- [x] All internal links resolve to existing files.
- [x] `AGENTS.md` line count <= 100 (verified: 75).
- [ ] End-to-end smoke test: assign `@copilot` to a `needs-triage` issue after merge and confirm Mode 2 fires (deferred until PR merges, since the cloud agent only reads `AGENTS.md` from the default branch).

## Out of scope

- Repo-root `AGENTS.md` link-check exclusion is not needed; `AGENTS.md` will exist on `main` immediately after merge.
- The `area:agents` label discussed in #228 Notes is a separate follow-up for `@repo-ops`.