### PR TITLE
Add needs-triage label to wiki-sync cron tracker issue

### DIFF
--- a/.github/workflows/wiki-sync-cron.yml
+++ b/.github/workflows/wiki-sync-cron.yml
@@ -118,5 +118,6 @@ jobs:
               --body-file "$BODY_FILE" \
               --label 'agent:wiki-sync' \
               --label 'chore' \
-              --label 'area:workflow'
+              --label 'area:workflow' \
+              --label 'needs-triage'
           fi


### PR DESCRIPTION
Routes the weekly wiki-sync tracker through the Triage Queue (board #19) per the rule that any agent-filed issue not coming through a direct-intake agent must land on 
eeds-triage first. Single-line workflow change adding a fourth label to the gh issue create call in wiki-sync-cron.yml.