### PR TITLE
Add copilot-setup-steps workflow for cloud agent prep

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,38 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: copilot-setup-steps-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium


### PR DESCRIPTION
Closes #34.

Adds the `copilot-setup-steps` workflow so the GitHub-hosted Copilot cloud agent has Node 20, repo dependencies, and Playwright browsers pre-installed before it runs lint/visual/link checks.

## Changes

- New `.github/workflows/copilot-setup-steps.yml`
- Job named `copilot-setup-steps` (required by GitHub).
- `permissions: contents: read` (least privilege).
- Triggers: `workflow_dispatch` plus `push`/`pull_request` filtered to the workflow file path.
- Actions pinned to SHA + major-version comment, matching repo convention.
- `timeout-minutes: 15`.
- Concurrency group keyed on `github.ref`.

## Tested

- `npm run lint` — clean.
- Workflow run on this PR (validates triggers + steps).
