### PR TITLE
Add agent-task label and issue template (#36)

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,46 @@
+name: Agent task (@copilot)
+description: Well-scoped task safe to assign to the GitHub Copilot cloud agent.
+title: "[agent-task] "
+labels: [agent-task]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when filing an issue you intend to assign to `@copilot` (the GitHub-hosted Copilot cloud agent).
+        Keep the scope tight — one branch, one PR. If the task is ambiguous or spans multiple concerns, split it first.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What needs to change and why. State the goal in one or two sentences.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Concrete, testable outcomes. Use a checklist; the agent ticks these off as it works.
+      value: |
+        - [ ] 
+        - [ ] 
+        - [ ] 
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-files
+    attributes:
+      label: Suggested files
+      description: Files or folders the agent should look at first. Helps it find the right context fast.
+      placeholder: |
+        - path/to/file.html
+        - .github/workflows/example.yml
+    validations:
+      required: false
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety confirmation
+      description: Confirm this task is appropriate for autonomous execution.
+      options:
+        - label: This issue is safe to assign to `@copilot` (well-scoped, no destructive operations on shared infra, no secrets needed beyond the default token).
+          required: true

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -71,6 +71,9 @@
 - name: agent:triage
   color: 8957e5
   description: Tasks for the @triage agent build or its findings
+- name: agent-task
+  color: c2a8ff
+  description: Issue is well-scoped and safe to assign to the @copilot cloud agent.
 
 # Lifecycle
 - name: needs-triage


### PR DESCRIPTION
Closes #36.

## Summary

- Adds `agent-task` label (color `c2a8ff`, lavender — coordinates with the `agent:*` purple family) marking issues as safe and well-scoped for `@copilot` cloud-agent assignment.
- Adds `.github/ISSUE_TEMPLATE/agent-task.yml` form template with: title prefix `[agent-task] `, problem statement (required), acceptance criteria checklist (required), suggested files (optional), and a required safety-confirmation checkbox.
- Template auto-applies the `agent-task` label via `labels: [agent-task]` in the form front matter.
- `labels.yml` updated alongside so `scripts/gh/sync-labels.ps1` provisions the label on next sync.

## Scope changes

The original issue had a fifth AC bullet coordinating with the LinkedIn-Sync agent (project #10). That agent has been removed from the portfolio, so the bullet was de-scoped on 2026-04-28. Issue body updated to match.

## Tested

- [x] `npm run lint` — htmlhint + stylelint clean.
- [x] YAML structure matches the existing `bug.yml` / `link-rot.yml` / `content-update.yml` form templates.
