### PR TITLE
boards-worker session: Wiki & Build-Docs Automation continuation (2026-04-28)

### DIFF
--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -25,6 +25,17 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 
 ## Sweep log
 
+### 2026-04-28 — boards-worker session: Wiki & Build-Docs Automation (#16) — continuation
+
+- **Branch:** `boards-worker/wiki-build-docs-20260428-2200` — PR _(opened at session close)_
+- **Operator:** boards-worker agent
+- **Context:** Continuation of the earlier 2026-04-28 session (PR #245) which drained #169, #171, #174. This session targets the remaining two Todo items on board #16.
+- **Queue at start (Todo, sorted by issue number):** #176, #177
+- **Status field options captured:** Source=Todo (`f75ad846`), In-flight=In Progress (`47fc9ee4`), In-review parking=_(none — using audit-log fallback per Status field handling)_, Done=Done (`98236657`)
+- **Schema mutations applied:** _(none)_
+- **Per-issue transitions:** _(populated as the batch runs)_
+- **Outcome:** _(populated at session close)_
+
 ### 2026-04-28 — boards-worker session: Wiki & Build-Docs Automation (#16)
 
 - **Branch:** `boards-worker/wiki-build-docs-20260428-2030` — PR _(opened at session close)_

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -35,6 +35,7 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 - **Schema mutations applied:** _(none)_
 - **Per-issue transitions:**
   - #176 Todo → In Progress at 2026-04-28T22:02-07:00
+  - #176 In Progress → Done — PR #246, merge `683d9a7`
 - **Outcome:** _(populated at session close)_
 
 ### 2026-04-28 — boards-worker session: Wiki & Build-Docs Automation (#16)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -33,7 +33,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 - **Queue at start (Todo, sorted by issue number):** #176, #177
 - **Status field options captured:** Source=Todo (`f75ad846`), In-flight=In Progress (`47fc9ee4`), In-review parking=_(none — using audit-log fallback per Status field handling)_, Done=Done (`98236657`)
 - **Schema mutations applied:** _(none)_
-- **Per-issue transitions:** _(populated as the batch runs)_
+- **Per-issue transitions:**
+  - #176 Todo → In Progress at 2026-04-28T22:02-07:00
 - **Outcome:** _(populated at session close)_
 
 ### 2026-04-28 — boards-worker session: Wiki & Build-Docs Automation (#16)

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -37,7 +37,8 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
   - #176 Todo → In Progress at 2026-04-28T22:02-07:00
   - #176 In Progress → Done — PR #246, merge `683d9a7`
   - #177 Todo → In Progress at 2026-04-28T22:18-07:00
-- **Outcome:** _(populated at session close)_
+  - #177 In Progress → Done — PR #247, merge `174347f`
+- **Outcome:** Clean drain — 2/2 worked, 0 blocked. Board #16 Todo column now empty. #176 added a wiki-sync-cron row to the Hygiene scouting table in `wiki/Workflows.md` (PR #246). #177 added a `@wiki-sync` row to `wiki/Agents.md`, refreshed the `@request-intake` and `@board-planner` rows for handoff/sweep behavior, and extended the handoff Mermaid diagram (PR #247). Note: the #177 issue context mentioned a LinkedIn-sync row but `wiki/LinkedIn-Sync.md` doesn't exist in the repo and no LinkedIn AC was listed — flagged in the issue resolution comment as a possible follow-up.
 
 ### 2026-04-28 — boards-worker session: Wiki & Build-Docs Automation (#16)
 

--- a/wiki/Boards.md
+++ b/wiki/Boards.md
@@ -36,6 +36,7 @@ Tracks the GitHub Projects (v2) **boards** used for portfolio work, plus the red
 - **Per-issue transitions:**
   - #176 Todo → In Progress at 2026-04-28T22:02-07:00
   - #176 In Progress → Done — PR #246, merge `683d9a7`
+  - #177 Todo → In Progress at 2026-04-28T22:18-07:00
 - **Outcome:** _(populated at session close)_
 
 ### 2026-04-28 — boards-worker session: Wiki & Build-Docs Automation (#16)


### PR DESCRIPTION
## Summary

Continuation of the earlier 2026-04-28 boards-worker session (PR #245). Drains the remaining 2 Todo items on board #16 (Wiki & Build-Docs Automation).

## Audit-log entry (verbatim from `wiki/Boards.md`)

### 2026-04-28 — boards-worker session: Wiki & Build-Docs Automation (#16) — continuation

- **Branch:** `boards-worker/wiki-build-docs-20260428-2200`
- **Operator:** boards-worker agent
- **Context:** Continuation of the earlier 2026-04-28 session (PR #245) which drained #169, #171, #174.
- **Queue at start (Todo, sorted by issue number):** #176, #177
- **Status field options captured:** Source=Todo (`f75ad846`), In-flight=In Progress (`47fc9ee4`), In-review parking=_(none — using audit-log fallback)_, Done=Done (`98236657`)
- **Schema mutations applied:** _(none)_
- **Per-issue transitions:**
  - #176 Todo → In Progress at 2026-04-28T22:02-07:00
  - #176 In Progress → Done — PR #246, merge `683d9a7`
  - #177 Todo → In Progress at 2026-04-28T22:18-07:00
  - #177 In Progress → Done — PR #247, merge `174347f`
- **Outcome:** Clean drain — 2/2 worked, 0 blocked. Board #16 Todo column now empty. #176 added a wiki-sync-cron row to the Hygiene scouting table in `wiki/Workflows.md`. #177 refreshed `wiki/Agents.md` for the wiki-sync agent and intake/planner extensions. Note: #177 context mentioned a LinkedIn-sync row but `wiki/LinkedIn-Sync.md` doesn't exist — flagged on the issue as a possible follow-up.

## Tested

- [x] All sub-PRs (#246, #247) merged with green checks
- [x] Both items now in Done on board #16
- [x] Audit-log entry appended to `wiki/Boards.md`
