### PR TITLE
Add CODEOWNERS to route reviews to maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+# Code ownership for marcusjacobson/portfolio
+#
+# This is a solo-maintained portfolio repo. The global rule routes every
+# review request to @marcusjacobson. The path-scoped rules below are not
+# different owners — they exist to make ownership intent explicit for the
+# areas that change most often (CI, agent/prompt config, wiki content) so
+# future contributors or automated tools can reason about review routing
+# without reading every workflow file.
+#
+# Syntax: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+# Global fallback — every path not matched below.
+*                           @marcusjacobson
+
+# Static site pages at the repo root (the actual published portfolio).
+/*.html                     @marcusjacobson
+
+# CI, Copilot agents, prompts, and instruction files.
+/.github/                   @marcusjacobson
+/.github/workflows/         @marcusjacobson
+/.github/agents/            @marcusjacobson
+/.github/prompts/           @marcusjacobson
+/.github/instructions/      @marcusjacobson
+
+# Wiki-as-code source (one-way synced to the GitHub wiki).
+/wiki/                      @marcusjacobson
+
+# Operations scripts (branch protection, board seeding, gh CLI helpers).
+/scripts/                   @marcusjacobson
+
+# Test config and visual snapshots.
+/tests/                     @marcusjacobson

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The site is hosted via [GitHub Pages](https://pages.github.com/) using the moder
 | `staging-inbox/` | Gitignored drop zone for the Claude project export. |
 | [`LICENSE`](LICENSE) | MIT License — terms under which the code and content may be reused. |
 | [`SECURITY.md`](SECURITY.md) | How to report a security issue privately, plus what is in and out of scope. |
+| [`.github/CODEOWNERS`](.github/CODEOWNERS) | Routes review requests to the maintainer for every path in the repo. |
 
 ## Workflows
 


### PR DESCRIPTION
Adds `.github/CODEOWNERS` so review requests on this repo route automatically to @marcusjacobson, and improves the GitHub community-profile score.

## Changes

- New `.github/CODEOWNERS` with a global fallback plus path-scoped rules for `*.html`, `.github/`, `wiki/`, `scripts/`, and `tests/`. All routes resolve to the sole maintainer; the path scoping makes ownership intent explicit for the areas that change most often, rather than leaving a one-line global rule.
- README repo-map row added pointing to the new file, alongside `LICENSE` and `SECURITY.md`.

## Notes

- Canonical path chosen: `.github/CODEOWNERS` (keeps repo root tidy; #117 just put `SECURITY.md` at the root, so this differentiates community files).
- No branch-protection change. There is no rule on this repo requiring CODEOWNERS review; this PR only registers ownership.

## Tested

- `npm run lint` — clean (htmlhint + stylelint).

Closes #119
