### PR TITLE
Add WCAG Option C scan: @axe-core/playwright (#127)

### DIFF
--- a/.github/workflows/maturity-scan.yml
+++ b/.github/workflows/maturity-scan.yml
@@ -7,6 +7,11 @@ on:
         description: "Max candidate issues to file in this run"
         required: false
         default: "5"
+      enable_axe_pw:
+        description: "Run Option C (Playwright + @axe-core/playwright) WCAG scan. Disabled by default to avoid double-filing alongside Option B (@axe-core/cli, #126). See wiki/Maturity-Scout.md."
+        required: false
+        type: boolean
+        default: false
   schedule:
     # 14:00 UTC every Monday — outside business hours but visible in morning sweeps.
     - cron: "0 14 * * 1"
@@ -815,6 +820,295 @@ jobs:
           {
             echo ""
             echo "## Maturity Scout — WCAG axe-core checks"
+            echo ""
+            echo "Pages scanned: ${#PAGES[@]} (axe ok: $AXE_OK, failed: $AXE_FAIL)"
+            echo ""
+            echo "Filed: $FILED"
+            if [[ -n "$SUMMARY_FILED" ]]; then echo "$SUMMARY_FILED"; fi
+            echo ""
+            echo "Suppressed: $SUPPRESSED"
+            if [[ -n "$SUMMARY_SUPPRESSED" ]]; then echo "$SUMMARY_SUPPRESSED"; fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          NEW_TOTAL=$((FILED_SO_FAR + FILED))
+          echo "filed_total=$NEW_TOTAL" >> "$GITHUB_OUTPUT"
+
+      # ---- WCAG Option C (issue #127): Playwright + @axe-core/playwright.
+      # Adds DOM-aware coverage with computed-style support (the
+      # prerequisite for `color-contrast`). Disabled by default to avoid
+      # double-filing alongside Option B (@axe-core/cli, #126); turn on
+      # via the `enable_axe_pw=true` workflow_dispatch input. The two
+      # scans share the same issue title format
+      # (`Fix axe-core violation: <rule> on portfolio pages`) so the
+      # dedupe pass below will suppress an Option C filing if Option B
+      # already filed the same rule earlier in the same run. See
+      # wiki/Maturity-Scout.md for the coexistence decision.
+      - name: Install Playwright browsers (Chromium) for Option C
+        if: github.event.inputs.enable_axe_pw == 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Run WCAG axe-core (Playwright) scan and file gap issues
+        id: scan_wcag_axe_pw
+        if: github.event.inputs.enable_axe_pw == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          MAX="${MAX_FILED}"
+          FILED_SO_FAR="${{ steps.scan_wcag_axe.outputs.filed_total }}"
+          if [[ -z "$FILED_SO_FAR" ]]; then
+            FILED_SO_FAR="${{ steps.scan_wcag.outputs.filed_total }}"
+          fi
+          if [[ -z "$FILED_SO_FAR" ]]; then
+            FILED_SO_FAR="${{ steps.scan_github_docs.outputs.filed_total }}"
+          fi
+          if [[ -z "$FILED_SO_FAR" ]]; then
+            FILED_SO_FAR="${{ steps.scan.outputs.filed }}"
+          fi
+          FILED_SO_FAR="${FILED_SO_FAR:-0}"
+
+          if [[ "$FILED_SO_FAR" -ge "$MAX" ]]; then
+            echo "Hit MAX ($MAX) in earlier steps; skipping Option C scan."
+            {
+              echo ""
+              echo "## Maturity Scout — WCAG axe-core (Playwright) checks"
+              echo ""
+              echo "Skipped: MAX cap of $MAX reached by earlier steps."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "filed_total=$FILED_SO_FAR" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # ---- Scope: top-level *.html only (matches the v1/Option B steps).
+          shopt -s nullglob
+          PAGES=()
+          for f in *.html; do
+            PAGES+=("$f")
+          done
+          shopt -u nullglob
+
+          if [[ "${#PAGES[@]}" -eq 0 ]]; then
+            echo "No top-level *.html pages found; skipping Option C scan."
+            {
+              echo ""
+              echo "## Maturity Scout — WCAG axe-core (Playwright) checks"
+              echo ""
+              echo "Skipped: no top-level portfolio pages."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "filed_total=$FILED_SO_FAR" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # ---- Boot a local static server so Playwright can hit each
+          # page over HTTP (axe-core's color-contrast rule needs computed
+          # styles from a real browser load).
+          mkdir -p .axe-pw-reports
+          npx --yes http-server -p 8080 -c-1 -s . >/tmp/http-server-pw.log 2>&1 &
+          SERVER_PID=$!
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -fsS "http://localhost:8080/index.html" -o /dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          if ! curl -fsS "http://localhost:8080/index.html" -o /dev/null; then
+            echo "::error::http-server failed to start on :8080 (Option C)"
+            cat /tmp/http-server-pw.log || true
+            kill "$SERVER_PID" >/dev/null 2>&1 || true
+            exit 1
+          fi
+          trap 'kill "$SERVER_PID" >/dev/null 2>&1 || true' EXIT
+
+          # ---- Run the Playwright a11y spec; it writes one JSON per
+          # page into .axe-pw-reports/. Tolerate non-zero exit so a
+          # single broken page doesn't abort the whole scan; we count
+          # successful JSON outputs below.
+          AXE_BASE_URL="http://localhost:8080/" \
+            npx playwright test --config tests/a11y/playwright.config.ts \
+            >/tmp/axe-pw.log 2>&1 || true
+
+          # Tally how many pages produced a JSON file.
+          AXE_OK=0
+          AXE_FAIL=0
+          for page in "${PAGES[@]}"; do
+            slug="${page%.html}"
+            if [[ -f ".axe-pw-reports/${slug}.json" ]]; then
+              AXE_OK=$((AXE_OK+1))
+            else
+              AXE_FAIL=$((AXE_FAIL+1))
+              echo "::warning::Option C produced no JSON for $page"
+            fi
+          done
+
+          if [[ "$AXE_OK" -eq 0 ]]; then
+            echo "::error::Option C scan produced no JSON for any page."
+            cat /tmp/axe-pw.log || true
+            {
+              echo ""
+              echo "## Maturity Scout — WCAG axe-core (Playwright) checks"
+              echo ""
+              echo "Failed: Option C scan produced no JSON for any page."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          # ---- Exclusion list: rules already covered by htmlhint and the
+          # v1 (regex) wcag scan. Mirrors the EXCLUDED_RULES in
+          # `scan_wcag_axe` so Option B and Option C produce identical
+          # candidate sets for the same DOM.
+          EXCLUDED_RULES=(
+            # htmlhint-enforced (per .htmlhintrc)
+            "alt-require"
+            "title-require"
+            "id-unique"
+            "tagname-lowercase"
+            "attr-no-duplication"
+            "src-not-empty"
+            "doctype-html5"
+            # v1 wcag scan (issue #113)
+            "html-has-lang"
+            "link-name"
+            "heading-order"
+          )
+
+          is_excluded () {
+            local r="$1"
+            for x in "${EXCLUDED_RULES[@]}"; do
+              if [[ "$r" == "$x" ]]; then return 0; fi
+            done
+            return 1
+          }
+
+          # ---- Aggregate violations across all pages by rule id.
+          # The Playwright spec wraps each result as a single-element
+          # array, matching the @axe-core/cli output shape so the same
+          # `(if type == "array" then .[0] else . end)` jq filter works.
+          : > /tmp/axe-pw-rows.tsv
+          for f in .axe-pw-reports/*.json; do
+            [[ -f "$f" ]] || continue
+            page=$(basename "$f" .json).html
+            jq -r --arg page "$page" '
+              (if type == "array" then .[0] else . end) as $r
+              | $r.violations[]?
+              | [
+                  .id,
+                  $page,
+                  (.impact // "unknown"),
+                  (.helpUrl // ""),
+                  ((.nodes[0].target[0]) // "")
+                ] | @tsv
+            ' "$f" >> /tmp/axe-pw-rows.tsv || true
+          done
+
+          declare -A RULE_COUNT
+          declare -A RULE_IMPACT
+          declare -A RULE_HELPURL
+          declare -A RULE_FINDINGS
+          ALL_RULES=""
+
+          while IFS=$'\t' read -r rule page impact helpUrl target; do
+            [[ -z "$rule" ]] && continue
+            if is_excluded "$rule"; then
+              continue
+            fi
+            if [[ -z "${RULE_COUNT[$rule]:-}" ]]; then
+              RULE_COUNT[$rule]=0
+              RULE_IMPACT[$rule]="$impact"
+              RULE_HELPURL[$rule]="$helpUrl"
+              RULE_FINDINGS[$rule]=""
+              ALL_RULES+="$rule"$'\n'
+            fi
+            RULE_COUNT[$rule]=$((RULE_COUNT[$rule]+1))
+            case "${RULE_IMPACT[$rule]}" in
+              critical) ;;
+              serious) [[ "$impact" == "critical" ]] && RULE_IMPACT[$rule]="$impact" ;;
+              moderate) [[ "$impact" == "critical" || "$impact" == "serious" ]] && RULE_IMPACT[$rule]="$impact" ;;
+              *) RULE_IMPACT[$rule]="$impact" ;;
+            esac
+            RULE_FINDINGS[$rule]+=$'- `'"$page"$'` — `'"${target:-(no selector)}"$'` (impact: '"$impact"$')\n'
+          done < /tmp/axe-pw-rows.tsv
+
+          UNIQUE_RULES=$(printf '%s' "$ALL_RULES" | sort -u)
+
+          if [[ -z "$UNIQUE_RULES" ]]; then
+            echo "No Option C violations after exclusion filter."
+            {
+              echo ""
+              echo "## Maturity Scout — WCAG axe-core (Playwright) checks"
+              echo ""
+              echo "Filed: 0 (no violations after filter)"
+              echo "Pages scanned: ${#PAGES[@]} (axe ok: $AXE_OK, failed: $AXE_FAIL)"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "filed_total=$FILED_SO_FAR" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # ---- Pre-fetch open source:wcag issues for dedupe. Title
+          # convention matches Option B verbatim
+          # (`Fix axe-core violation: <rule> on portfolio pages`) so the
+          # `contains($r)` jq match catches both scans uniformly.
+          OPEN_WCAG=$(gh issue list \
+            --state open \
+            --search 'label:source:wcag' \
+            --json number,title,url \
+            --limit 200)
+
+          FILED=0
+          SUPPRESSED=0
+          SUMMARY_FILED=""
+          SUMMARY_SUPPRESSED=""
+
+          while IFS= read -r rule; do
+            [[ -z "$rule" ]] && continue
+
+            if [[ $((FILED_SO_FAR + FILED)) -ge "$MAX" ]]; then
+              echo "Hit MAX ($MAX); skipping rule $rule."
+              SUMMARY_SUPPRESSED+=$'\n  - '"$rule"$' — skipped (MAX cap reached)'
+              SUPPRESSED=$((SUPPRESSED+1))
+              continue
+            fi
+
+            count="${RULE_COUNT[$rule]}"
+            impact="${RULE_IMPACT[$rule]}"
+            helpUrl="${RULE_HELPURL[$rule]}"
+            findings="${RULE_FINDINGS[$rule]%$'\n'}"
+            title="Fix axe-core violation: ${rule} on portfolio pages"
+
+            match=$(echo "$OPEN_WCAG" | jq -r --arg r "$rule" \
+              '[.[] | select(.title | contains($r))] | .[0] // empty | "\(.number)|\(.url)"')
+            if [[ -n "$match" ]]; then
+              echo "Dedup suppressed ($rule): existing open issue $match"
+              SUMMARY_SUPPRESSED+=$'\n  - '"$rule"$' — overlaps with '"$match"
+              SUPPRESSED=$((SUPPRESSED+1))
+              continue
+            fi
+
+            template=$(cat .github/workflows/templates/wcag-axe-pw-issue-body.md)
+            template="${template//__RULE__/$rule}"
+            template="${template//__COUNT__/$count}"
+            template="${template//__IMPACT__/$impact}"
+            template="${template//__HELP_URL__/$helpUrl}"
+            template="${template//__FINDINGS__/$findings}"
+            body_file=$(mktemp)
+            printf '%s\n' "$template" > "$body_file"
+
+            echo "Filing ($rule): $title"
+            url=$(gh issue create \
+              --title "$title" \
+              --label "needs-triage,source:wcag,area:html" \
+              --body-file "$body_file")
+            rm -f "$body_file"
+
+            GH_TOKEN="$PROJECT_TOKEN" gh project item-add 15 \
+              --owner marcusjacobson --url "$url" >/dev/null
+
+            FILED=$((FILED+1))
+            SUMMARY_FILED+=$'\n  - '"$url"$' — '"$title"
+          done <<< "$UNIQUE_RULES"
+
+          {
+            echo ""
+            echo "## Maturity Scout — WCAG axe-core (Playwright) checks"
             echo ""
             echo "Pages scanned: ${#PAGES[@]} (axe ok: $AXE_OK, failed: $AXE_FAIL)"
             echo ""

--- a/.github/workflows/templates/wcag-axe-pw-issue-body.md
+++ b/.github/workflows/templates/wcag-axe-pw-issue-body.md
@@ -1,0 +1,40 @@
+## Source
+
+WCAG 2.2 axe-core scan (Playwright + `@axe-core/playwright`) flagged the rule **`__RULE__`** on __COUNT__ portfolio page(s). This is the **Option C** pass run by `.github/workflows/maturity-scan.yml` step `scan_wcag_axe_pw`: it boots a local static server, drives each top-level `*.html` portfolio page through Playwright (full DOM + computed styles), and runs `@axe-core/playwright` against the rendered page. Unlike the Option B `@axe-core/cli` scan (#126), this pass can resolve `color-contrast` against actual computed CSS.
+
+Rules already enforced by `htmlhint` (PR `lint`) and the v1 regex pass from #113 (`html-has-lang`, `link-name`, `heading-order`) are filtered out before any issue is filed.
+
+## Why it matters
+
+`axe-core` flags a violation against WCAG 2.2 / Section 508 success criteria. Each occurrence affects assistive-technology users on the live portfolio:
+
+- Rule documentation: <__HELP_URL__>
+- Impact level reported by axe: **__IMPACT__**
+
+The Option B CLI scan cannot reliably surface this rule (or surfaces it without enough DOM context to act on it); the Playwright pass loads the page in a real browser engine, which is the prerequisite for `color-contrast` and any rule that depends on computed styles or layout.
+
+## Suggested change
+
+Address every page listed below so the rule no longer fires. Re-run the Option C scan locally to confirm:
+
+```bash
+npx http-server -p 8080 -s . &
+AXE_BASE_URL=http://localhost:8080/ npm run test:a11y
+```
+
+The fix should not introduce new `htmlhint` failures in the PR `lint` job and should not regress the v1 `source:wcag` rules.
+
+## Acceptance criteria
+
+- [ ] Every page listed below passes the rule when re-scanned by `@axe-core/playwright` (no remaining violation for `__RULE__`).
+- [ ] Fix does not introduce any new `htmlhint` failures in the PR `lint` job.
+- [ ] Fix does not introduce any new violations for the v1 `source:wcag` rules (`html-has-lang`, `link-name`, `heading-order`).
+- [ ] Visual-regression snapshots updated only if the fix changes rendered output.
+
+Findings (__COUNT__):
+
+__FINDINGS__
+
+## Notes
+
+This is the WCAG Option C (Playwright + `@axe-core/playwright`) scan added in #127. Option B (`@axe-core/cli`, #126) and Option C currently coexist: Option B runs on every scheduled cron; Option C runs only when the workflow is manually dispatched with `enable_axe_pw=true`. Both pass shapes file under the same title format (`Fix axe-core violation: <rule> on portfolio pages`) so the dedupe pass keeps either scan from double-filing if both ever run unattended in the same run. See `wiki/Maturity-Scout.md` for the coexistence decision and the planned consolidation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@axe-core/cli": "^4.10.1",
+        "@axe-core/playwright": "^4.10.1",
         "@playwright/test": "^1.48.0",
         "htmlhint": "^1.1.4",
         "http-server": "^14.1.1",
@@ -46,6 +47,29 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright/node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@axe-core/webdriverjs": {

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "lint:css": "stylelint \"**/*.css\" --allow-empty-input",
     "lint": "npm run lint:html && npm run lint:css",
     "test:visual": "playwright test --config tests/playwright.config.ts",
-    "test:visual:update": "playwright test --config tests/playwright.config.ts --update-snapshots"
+    "test:visual:update": "playwright test --config tests/playwright.config.ts --update-snapshots",
+    "test:a11y": "playwright test --config tests/a11y/playwright.config.ts"
   },
   "devDependencies": {
     "@axe-core/cli": "^4.10.1",
+    "@axe-core/playwright": "^4.10.1",
     "@playwright/test": "^1.48.0",
     "htmlhint": "^1.1.4",
     "http-server": "^14.1.1",

--- a/tests/a11y/axe.spec.ts
+++ b/tests/a11y/axe.spec.ts
@@ -1,0 +1,54 @@
+import { test } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Issue #127 — WCAG axe-core scan run via Playwright.
+//
+// Loads each top-level portfolio page over the Playwright `baseURL`
+// (the maturity-scan workflow boots a local http-server on :8080
+// before invoking this spec) and runs axe-core against the rendered
+// DOM. Unlike `@axe-core/cli` (Option B, issue #126), this exercises
+// the full computed-style tree, which is the prerequisite for
+// `color-contrast` findings.
+//
+// Each page's axe results are written as JSON to
+// `<repoRoot>/.axe-pw-reports/<page-slug>.json`. The workflow's
+// `scan_wcag_axe_pw` step aggregates that directory using the same
+// rule-id grouping logic as Option B.
+
+const repoRoot = resolve(__dirname, '..', '..');
+const reportDir = resolve(repoRoot, '.axe-pw-reports');
+
+// Same scope as the workflow: every top-level *.html in the repo root.
+function discoverPages(): string[] {
+  return readdirSync(repoRoot)
+    .filter((name) => name.toLowerCase().endsWith('.html'))
+    .sort();
+}
+
+const PAGES = discoverPages();
+
+mkdirSync(reportDir, { recursive: true });
+
+// Tag set mirrors Option B (`@axe-core/cli --tags ...`) so the rule
+// surface is comparable when both scans run.
+const AXE_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'];
+
+for (const page of PAGES) {
+  test(`axe: ${page}`, async ({ page: pw }) => {
+    await pw.goto(page);
+    await pw.waitForLoadState('networkidle');
+
+    const results = await new AxeBuilder({ page: pw })
+      .withTags(AXE_TAGS)
+      .analyze();
+
+    const slug = page.replace(/\.html$/i, '');
+    const outPath = resolve(reportDir, `${slug}.json`);
+    // Wrap as a single-element array so the aggregator can use the
+    // same `(if type == "array" then .[0] else . end)` jq shape used
+    // for the @axe-core/cli output.
+    writeFileSync(outPath, JSON.stringify([results], null, 2), 'utf8');
+  });
+}

--- a/tests/a11y/playwright.config.ts
+++ b/tests/a11y/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Dedicated config for the WCAG axe-core a11y scan (issue #127).
+// Kept separate from `tests/playwright.config.ts` so the visual-regression
+// run is unaffected. The spec writes JSON reports to `.axe-pw-reports/`
+// at the repo root; the maturity-scan workflow aggregates them.
+//
+// `AXE_BASE_URL` lets the workflow point at the locally booted
+// http-server (matches the Option B / `@axe-core/cli` pattern). When
+// running locally without a server, set it to a `file://` URL or run
+// `npx http-server -p 8080 -s .` from the repo root first.
+const baseURL = process.env.AXE_BASE_URL || 'http://localhost:8080/';
+
+export default defineConfig({
+  testDir: '.',
+  fullyParallel: true,
+  reporter: [['list']],
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'desktop', use: { viewport: { width: 1440, height: 900 } } },
+  ],
+});

--- a/tests/a11y/playwright.config.ts
+++ b/tests/a11y/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig } from '@playwright/test';
 
 // Dedicated config for the WCAG axe-core a11y scan (issue #127).
 // Kept separate from `tests/playwright.config.ts` so the visual-regression

--- a/wiki/Maturity-Scout.md
+++ b/wiki/Maturity-Scout.md
@@ -40,7 +40,7 @@ This is the canonical answer to "why did the weekly scan find so few things?" Au
 |---|---|---|---|---|
 | `source:repo-hygiene` | `maturity-scan.yml` step `scan` | 7 file-existence checks: `SECURITY.md`, `CONTRIBUTING.md`, `CODEOWNERS`, `.github/ISSUE_TEMPLATE`, `.github/PULL_REQUEST_TEMPLATE.md`, `.github/dependabot.yml`, `LICENSE` | Branch-protection drift detection (compare `scripts/apply-branch-protection.ps1` baseline vs. live API state); label drift (`.github/labels.yml` vs. `gh label list`); stale-workflow detection (referenced action no longer exists upstream); auto-merge / require-review baseline drift | **Expand** — follow-up #256 filed for branch-protection + label drift producer. |
 | `source:github-docs` | `maturity-scan.yml` step `scan_github_docs` | 1 rule: action SHA-pin audit across `.github/workflows/*.yml` | CODEOWNERS shape validation (path globs cover the surfaces they need to); branch-protection doc completeness (does the wiki match what's enforced?); `permissions:` block presence on every workflow; concurrency block hygiene; `pull_request_target` usage audit | **Expand** — follow-up #257 filed for `permissions:`-presence, CODEOWNERS shape, and reusable-workflow pin checks. |
-| `source:wcag` | `maturity-scan.yml` steps `scan_wcag` (v1, regex) and `scan_wcag_axe` (v2, axe-core CLI against a local static server) | v1: 3 regex rules — `html-has-lang` (3.1.1), `link-name` (4.1.2), `heading-order` (1.3.1). v2 (#126): every `@axe-core/cli` rule under tags `wcag2a,wcag2aa,wcag21a,wcag21aa,wcag22aa`, minus rules already covered by `htmlhint` and v1. Both pass scope to the 6 top-level `*.html` portfolio pages. | Multi-page flow checks, keyboard navigation, focus-trap interaction — anything that needs Playwright-driven DOM interaction rather than a single static load. | **v1 + v2 shipped** in #113 and #126. Playwright + axe-core integration tracked in #127 and stays gated on a runtime decision. |
+| `source:wcag` | `maturity-scan.yml` steps `scan_wcag` (v1, regex), `scan_wcag_axe` (v2 / Option B, axe-core CLI against a local static server), and `scan_wcag_axe_pw` (Option C, axe-core driven via Playwright — disabled by default) | v1: 3 regex rules — `html-has-lang` (3.1.1), `link-name` (4.1.2), `heading-order` (1.3.1). Option B (#126): every `@axe-core/cli` rule under tags `wcag2a,wcag2aa,wcag21a,wcag21aa,wcag22aa`, minus rules already covered by `htmlhint` and v1. Option C (#127): same tag set and exclusion list run via `@axe-core/playwright` so computed-style rules (e.g. `color-contrast`) can fire. All three pass scope to the 6 top-level `*.html` portfolio pages. | Multi-page flow checks, keyboard navigation, focus-trap interaction — anything that needs cross-page Playwright-driven DOM interaction rather than a single static load. | **v1 + Option B + Option C shipped** in #113, #126, and #127. Option C is gated behind a `workflow_dispatch` flag pending a head-to-head comparison run; see [Option B vs. Option C](#option-b-vs-option-c-coexistence) below. |
 | `source:owasp` | None — unwired | None | Static checks deterministic for a static-HTML site: external `<script src=...>` without `integrity=` (SRI); `<link rel="stylesheet" href=...>` without `integrity=`; `target="_blank"` without `rel="noopener noreferrer"`; mixed-content (`http://` references in `*.html`); inline `<script>` blocks vs. CSP posture | **Expand** — follow-up #255 filed to add a producer step. |
 | `source:ms-learn` | None — unwired (by design) | None | Microsoft Learn page coverage for the security technologies claimed on the portfolio — every check requires LLM judgment to map a Learn page to a portfolio claim and assess whether the claim is current. | **Defer indefinitely — keep chat-mode only.** Adding a deterministic producer for this lane is not viable; the value is in the LLM-driven `@maturity-scout` chat audits already documented above. No follow-up issue. If a future deterministic check is identified (e.g. "the cert badge URL on `certification_strategy.html` resolves and matches the claimed exam code"), file it then. |
 
@@ -90,7 +90,8 @@ What it does:
 - `source:github-docs` v1 covers the action SHA-pin audit only — it scans every `.github/workflows/*.yml` file and files **one consolidated issue** per run when any `uses:` ref is not pinned to a 40-character commit SHA. Other github-docs checks (CODEOWNERS shape, branch-protection doc completeness) remain on-demand under `@maturity-scout` until added in a follow-up.
 - `source:wcag` v1 covers three regex-only static checks across the six top-level `*.html` portfolio pages: `html-has-lang` (WCAG 3.1.1), `link-name` (WCAG 4.1.2), and `heading-order` (WCAG 1.3.1). Each rule files at most one consolidated issue per run, listing every page that fails.
 - `source:wcag` v2 (added in #126) extends coverage via `@axe-core/cli` against a local `http-server` instance booted in CI. The step runs after v1, filters out rule ids already enforced by `htmlhint` (`alt-require`, `title-require`, `id-unique`, `tagname-lowercase`, `attr-no-duplication`, `src-not-empty`, `doctype-html5`) and the three v1 rules, dedupes against open `source:wcag` issues by rule id in title, and files **one issue per remaining failing rule id** with the same `needs-triage,source:wcag,area:html` label set. The v1 + v2 + earlier scan steps share a single MAX cap (chained via step outputs). Network egress: the step installs `@axe-core/cli` from the cached `npm ci` plus loads the locally served pages; no live external service is queried.
-- Playwright + axe-core integration is tracked separately in #127 and stays gated on a runtime decision (Playwright-driven flow tests vs. the simpler v2 scan above).
+- `source:wcag` Option C (added in #127) extends coverage further via `@axe-core/playwright` driving a real Chromium load of each page, which is the prerequisite for any rule that needs computed styles (notably `color-contrast`). Option C is **disabled by default** to avoid double-filing alongside Option B; it runs only when the workflow is dispatched manually with `enable_axe_pw=true`. Both Option B and Option C use the same issue title format (`Fix axe-core violation: <rule> on portfolio pages`), the same exclusion list, and the same MAX cap chain — so even if both ever ran in the same run, the title-prefix dedupe pass would suppress the second filing for any rule already covered by the first. See the [Option B vs. Option C](#option-b-vs-option-c-coexistence) section below for the consolidation plan.
+- Playwright + axe-core integration is shipped as Option C above (#127). The runtime tradeoff (Option B is fast and CLI-only; Option C needs `npx playwright install --with-deps chromium` and a real browser load per page) is the reason Option C stays manual-dispatch only for now.
 - Runs deterministic file-existence checks against the checkout (no live external fetches).
 - Performs the same dedupe pass against open issues and board items via `gh`.
 - Files each surviving candidate with `needs-triage`, the matching `source:*` label, and the matching `area:*` label.
@@ -176,6 +177,34 @@ Do **not** edit the issue's labels to "retrigger" the fallback `maturity-autoadd
 If `maturity-scan.yml` ever needs to label issues itself (today it relies on `gh issue create --label` running under the default `GITHUB_TOKEN`, which has `issues: write` from the workflow's `permissions:` block), keep the two-token split: probe / attach with `BUG_PROJECT_TOKEN`, label with `secrets.GITHUB_TOKEN`. See PR #83 for the canonical pattern. **Do not widen the PAT scope** — it is shared with `bug-autoadd.yml`, `project-autoadd.yml`, and `project-converted-issue.yml`, and broader scope expands the blast radius across all four workflows.
 
 The same constraint is captured in the repo's stored agent memory under "BUG_PROJECT_TOKEN classic PAT scope limits".
+
+## Option B vs. Option C coexistence
+
+Both the `@axe-core/cli` scan (Option B, #126) and the `@axe-core/playwright` scan (Option C, #127) currently live in `maturity-scan.yml`. The decision in #127 was to **keep both checked in but only run one unattended** until we have a side-by-side comparison from a real run.
+
+| | Option B — `scan_wcag_axe` | Option C — `scan_wcag_axe_pw` |
+|---|---|---|
+| Tool | `@axe-core/cli` against `http://localhost:8080/<page>` | `@axe-core/playwright` driving a real Chromium load |
+| When it runs | Every scheduled cron + every `workflow_dispatch` | Only when dispatched with `enable_axe_pw=true` |
+| Computed-style rules (e.g. `color-contrast`) | No — CLI loads pages without a real layout engine | Yes — full Chromium with computed styles |
+| CI cost | Light — `npm ci` is already cached | Heavier — adds `npx playwright install --with-deps chromium` |
+| Title format | `Fix axe-core violation: <rule> on portfolio pages` | Same — verbatim |
+| Body template | `.github/workflows/templates/wcag-axe-issue-body.md` | `.github/workflows/templates/wcag-axe-pw-issue-body.md` |
+| Exclusion list | htmlhint-covered rules + v1 regex rules | Identical to Option B |
+| MAX cap | Shares the chain — consumes `scan_wcag.outputs.filed_total`, emits its own | Shares the chain — consumes `scan_wcag_axe.outputs.filed_total`, emits its own |
+
+Why both stay in the repo for now:
+
+- Option C is the only path to `color-contrast` findings, which is the single biggest gap Option B can't close.
+- Running Option C on every cron without first comparing its output to Option B risks a flood of duplicate filings on first contact (e.g. when one scan reports `nested-interactive` against a page the other reports `aria-allowed-role` against the same selector).
+- Title-format parity means the Option C dedupe pass will silently suppress any rule Option B already filed in an earlier step of the same run, so the worst case is a no-op rather than double-filing.
+
+Consolidation plan (follow-up issue to be filed once the comparison run is in hand):
+
+1. Dispatch `Maturity Scout` manually with `enable_axe_pw=true` and `max=20` so both scans run end-to-end on the same DOM.
+2. Diff the two filed-issue sets by rule id. Triage any rule Option C reports but Option B doesn't (likely `color-contrast`, possibly `aria-hidden-focus` or `nested-interactive`).
+3. If Option C is a strict superset, retire Option B (delete the `scan_wcag_axe` step + `wcag-axe-issue-body.md`, drop `@axe-core/cli` from `package.json`) and flip `enable_axe_pw` to default-true (or remove the gate entirely).
+4. If Option B has its own unique rule coverage worth keeping, leave both wired and drop Option C's `if:` gate so it runs every cron — the title-prefix dedupe is already proved out by step 1.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Adds **Option C** of the WCAG axe-core scan — `@axe-core/playwright` driving a real Chromium load — alongside the existing **Option B** (`@axe-core/cli`) scan shipped in #126. Option C is the only path to `color-contrast` findings (and other rules that need computed styles), which is the gap #127 exists to close.

Closes #127. Implements every AC verbatim. Gated behind #126 (now merged in #259).

## Decision: Option B and Option C coexist; Option C is opt-in

The cleanest landing per the issue's "supersedes vs. coexist" callout is to **keep Option B as-is on every cron** and **add Option C as a parallel step disabled by default**, gated on a new `workflow_dispatch` input `enable_axe_pw` (default `false`). Rationale, with full diff in `wiki/Maturity-Scout.md`:

- Option C's value is `color-contrast` + other computed-style rules. We don't yet know what that looks like on the live portfolio.
- Running Option C on every cron without first comparing to Option B risks a flood of duplicate filings on first contact.
- Both scans use the **same issue title format** (`Fix axe-core violation: <rule> on portfolio pages`) and feed the same dedupe pass, so even if both ever run in the same run the worst case is a no-op suppression — never a double-filing.
- Consolidation plan is documented in the new "Option B vs. Option C coexistence" wiki section: dispatch once with `enable_axe_pw=true`, diff the rule sets, and either retire Option B or remove the `if:` gate on Option C in a follow-up issue.

## AC traceability

| AC | Where |
|---|---|
| Add `@axe-core/playwright` as devDependency | [package.json](package.json) |
| New Playwright spec under `tests/a11y/` writing JSON to known artifact path | [tests/a11y/axe.spec.ts](tests/a11y/axe.spec.ts), [tests/a11y/playwright.config.ts](tests/a11y/playwright.config.ts) — writes `<repo>/.axe-pw-reports/<slug>.json` |
| `maturity-scan.yml` invokes the spec and parses the JSON artifact | [.github/workflows/maturity-scan.yml](.github/workflows/maturity-scan.yml) — new step `scan_wcag_axe_pw` |
| Filter logic identical to Option B (drop htmlhint-covered + Option-A-covered rules) | Same `EXCLUDED_RULES` array as `scan_wcag_axe` |
| Includes `color-contrast` findings | Tag set `wcag2a,wcag2aa,wcag21a,wcag21aa,wcag22aa` includes `color-contrast`; only Option C can resolve it because `axe.run()` runs in a real browser |
| One issue per failing rule id; dedupe by title; cap shared with other scan steps | Same RULE_* aggregation pattern as Option B; consumes `steps.scan_wcag_axe.outputs.filed_total`, emits its own `filed_total` |
| Documents in `wiki/Maturity-Scout.md` why this supersedes Option B if both are kept | New "Option B vs. Option C coexistence" section + refreshed coverage matrix row + refreshed weekly automation contract |

## Tested

- `npm ci` clean.
- `npm run lint` — `htmlhint` clean across 7 files; `stylelint` clean.
- YAML parse of `.github/workflows/maturity-scan.yml` — clean.
- Spec is **not** wired into the existing visual-regression run (separate `tests/a11y/playwright.config.ts`) so it cannot regress `npm run test:visual`.
- Option C step is gated `if: github.event.inputs.enable_axe_pw == 'true'`, so this PR does not change the scheduled cron behavior; the scheduled run still runs Option B only.

## Notes

- The Playwright spec wraps each result as a single-element array (`JSON.stringify([results], …)`) so the bash aggregator can use the same `(if type == "array" then .[0] else . end)` jq filter as the Option B step. No special-casing in the workflow.
- All new step references reuse already-pinned actions (`actions/setup-node` is shared with Option B); the only new shell call is `npx playwright install --with-deps chromium`, which is a pinned npm package.
- `permissions:` block on the workflow is unchanged.

## Checklist

- [x] One issue → one PR (Closes #127)
- [x] Lint clean
- [x] No edits to `tests/visual/__snapshots__/`
- [x] Action versions still pinned by SHA where required
- [x] Workflow `permissions:` block unchanged (`contents: read`, `issues: write`)
- [x] Wiki updated to document the decision
