### PR TITLE
Slim copilot-instructions to always-on core

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,88 +1,53 @@
 # Repo conventions for Copilot
 
-> **No build step.** This is a static HTML portfolio site published to GitHub Pages. Every `*.html` page must be browser-runnable as-is from the repo root. There is no bundler, no transpiler, no `npm run build` for the site itself. The `npm` toolchain (under `package.json`) is purely dev-time tooling for lint, link-check, and visual regression.
+> **No build step.** Static HTML portfolio on GitHub Pages. Every `*.html` page must be browser-runnable as-is from the repo root. `npm` is dev-time tooling only (lint, link-check, visual regression). Do not invent a `build` step.
 
-> **Two contexts, one repo.** This file is the canonical guide for **VS Code Copilot Chat** (interactive, has access to local agents, prompts, and slash-commands). The hosted **Copilot cloud (coding) agent** loads [AGENTS.md](../AGENTS.md) instead. When working as the cloud agent, follow [AGENTS.md](../AGENTS.md) — it is the smaller, resolver-only contract. Do not assume slash-prompts or named local agents are available in cloud runs.
-
-## Site authoring
-
-- Pages live at the repo root: `index.html`, `ms_security_compass.html`, `ms_security_roles.html`, `ms_security_projects.html`, `certification_strategy.html`, `skills_inventory.html`. Keep this filename scheme (no version suffixes).
-- Inline CSS and JS are acceptable for self-contained pages; if you extract assets, place them under `assets/` and reference with relative paths.
-- Every page must have `<!DOCTYPE html>`, `<html lang="en">`, a `<title>`, and a meta viewport tag.
-- All `<img>` tags must have `alt` attributes (enforced by `htmlhint`).
-- Prefer system fonts; if you load an external font, use `rel="preconnect"` and `display=swap`.
-- Do not commit secrets, PATs, or personal data. `gitleaks` runs on every PR.
-
-## Tooling layout
-
-| Folder | Purpose |
-|--------|---------|
-| `AGENTS.md` (root) | Cloud-agent contract loaded by the hosted Copilot cloud agent on every run. Resolver-only: any assigned issue → branch + one PR. Triage stays in local chat. |
-| `.github/workflows/` | CI: deploy, previews, link-check, lint, visual regression, CodeQL, gitleaks, wiki sync |
-| `.github/instructions/` | Scoped Copilot guidance (auto-attaches by `applyTo`) |
-| `.github/prompts/` | Slash-command tasks (publish, secure review, staging, triage) |
-| `.github/agents/` | Specialized chat agents (publish-manager, security-reviewer, repo-ops) |
-| `scripts/` | PowerShell ops scripts (migration, branch protection, gh CLI helpers) |
-| `tests/` | Lychee config, Playwright config, visual specs and snapshots |
-| `wiki/` | Wiki-as-code source. Synced one-way to the GitHub wiki by `wiki-sync.yml` |
-| `staging-inbox/` | Gitignored drop zone for the Claude project export |
+> **Two contexts.** This file is the always-on guide for **VS Code Copilot Chat**. The hosted **cloud agent** loads [AGENTS.md](../AGENTS.md) — that is the resolver-only contract. Local agents (`@*`) and slash-prompts (`/*`) only exist in chat.
 
 ## Hard rules
 
-- **Never edit `tests/visual/__snapshots__/` by hand.** Regenerate with `npm run test:visual:update`.
-- **Never push directly to `main`.** Open a PR; checks must be green.
-- **Pin Action versions** in `.github/workflows/*.yml`. Use major version tags (`@v4`) at minimum; SHAs preferred for third-party actions.
-- **`permissions:` is required** on every workflow. Default to `contents: read` and elevate per job only as needed.
+- **Never push directly to `main`.** Open a PR; required checks must be green.
+- **Never edit `tests/visual/__snapshots__/` by hand.** Regenerate via `npm run test:visual:update`.
+- **Pin Action versions** in `.github/workflows/*.yml` (major tag minimum; SHA for third-party).
+- **`permissions:` is required** on every workflow. Default `contents: read`; elevate per job.
+- **No secrets, PATs, or personal data** in the repo. `gitleaks` runs on every PR.
+- All `<img>` tags need `alt` attributes (`htmlhint` enforces).
+- Commit subject: imperative, ≤72 chars. PR description: summary + screenshots for visual changes + tested checklist.
 
-## Verified shell commands
+## Verified commands
 
-These commands are known to work in both the local dev environment and the ephemeral cloud-agent runner (after `copilot-setup-steps` has primed Node 20 and dependencies):
+`npm ci` · `npm run lint` · `npm run test:visual` · `npm run test:visual:update` · `npx lychee --config tests/lychee.toml .`
 
-| Command | Purpose |
-|---------|---------|
-| `npm ci` | Install dev dependencies (idempotent; required after `package-lock.json` changes). |
-| `npm run lint` | Runs `htmlhint` against `*.html` and `stylelint` against `**/*.css`. |
-| `npm run test:visual` | Playwright visual regression. Snapshots live in `tests/visual/__snapshots__/`. |
-| `npm run test:visual:update` | Regenerate visual snapshots. The **only** sanctioned way to change them. |
-| `npx lychee --config tests/lychee.toml .` | Local link-check (CI runs the same via `link-check.yml`). |
+## Where to look (load on demand, not preloaded)
 
-The cloud agent does not have a separate `npm run build` step because the site has no build. Do not invent one.
-
-## When working as the cloud (hosted) agent
-
-If you are running as the GitHub-hosted Copilot coding agent (assigned to an issue from the Agents tab or via `@copilot`), follow [AGENTS.md](../AGENTS.md) as the primary contract. Key cloud-agent specifics that override or narrow the rules above:
-
-- **One issue → one branch → one PR.** Never bundle multiple issues into a single PR. Triage is **not** your job; if an issue is unclear, comment on it and stop.
-- **Triage stays in local chat.** If you are assigned a `needs-triage` issue, the maintainer triaged it in local chat first and removed that label before assigning you. Do not edit triage labels yourself.
-- **Budget discipline.** Expect roughly one premium request per task. If the first attempt fails, diagnose and try a different approach. Do not retry the same approach more than twice — comment on the issue with the blocker and stop.
-- **No interactive prompts.** You cannot ask the maintainer questions mid-run. If you need confirmation (destructive action, ambiguous AC, schema change), post a comment and stop instead of guessing.
-- **Local agents and slash-prompts are not available** in cloud runs. References in this file to `@publish-manager`, `@security-reviewer`, `@repo-ops`, `/publish-update`, `/secure-code-review`, etc. only apply in VS Code chat.
-
-## Commit & PR style
-
-- Commit messages: imperative subject, ≤72 chars; body explains *why* if non-obvious.
-- PR title: same style as commit subject.
-- PR description must include: summary, screenshots for visual changes, and a tested checklist.
-
-## When the user asks to publish, review, or stage
-
-- Publishing → use `/publish-update` prompt or the `@publish-manager` agent.
-- Security review → use `/secure-code-review` prompt or `@security-reviewer` agent.
-- Issues / Boards / Wiki ops → use `@repo-ops` (uses `gh` CLI and the GitHub MCP server).
-- Triage of `needs-triage` issues (confirm for work or dismiss) → use the `@triage` agent in local Copilot Chat. Operates one issue at a time. Presents a proposal and waits for `apply` / `dismiss` / `edit:` / `cancel`. Triage is **chat-only**; the hosted cloud agent does not run triage.
-- Cleanup / sweep stale artefacts → use `/repo-cleanup` or the `@repo-cleanup` agent. Walks generated test outputs, `staging-inbox/` leftovers, merged local branches, stale `.copilot-tracking/` runs, orphaned scripts, and versioned root duplicates one item at a time. Read-only until per-item approval; `keep` produces a remediation so the same item isn't re-flagged.
+| Context | File |
+|---------|------|
+| HTML page authoring | [.github/instructions/html-pages.instructions.md](instructions/html-pages.instructions.md) (auto-attaches to `*.html`) |
+| Wiki authoring | [.github/instructions/wiki-content.instructions.md](instructions/wiki-content.instructions.md) (auto-attaches to `wiki/**`) |
+| Workflow authoring | [.github/instructions/workflows.instructions.md](instructions/workflows.instructions.md) (auto-attaches to `.github/workflows/**`) |
+| Cloud-agent contract | [AGENTS.md](../AGENTS.md) |
+| Folder map, full architecture | [wiki/Repo-Architecture.md](../wiki/Repo-Architecture.md) |
+| Full agent catalog + handoffs | [wiki/Agents.md](../wiki/Agents.md) |
 
 ## Request intake (always-on)
 
-For **any new feature/bug/chore-shaped request** the user makes in this repo, before implementing, route it through the appropriate intake agent. The intake agent classifies the request, drafts a GitHub issue, checks for duplicates, picks a board home, and waits for explicit approval before mutating anything.
+For any **new feature/bug/chore-shaped request**, route through an intake agent before implementing. The intake agent classifies, drafts an issue, picks a board, and waits for explicit approval. Skip intake for: pure questions, mid-flow on an existing issue/PR, the user says `skip intake` / `just do it` / `quick fix`, or a typo / single-line / comment edit on a named file.
 
-Bug-shaped requests (broken, regressed, or buggy behavior — "X is broken on mobile", "the modal scrolls past the viewport", a screenshot of something visibly wrong) route to `@bug-intake` first. It uses a bug-specific template (repro steps, expected/actual, environment, evidence) and routes to a dedicated bug-tracking board. New-project-shaped requests (a new portfolio project, capstone, or future security initiative — "onboard a new project for X", "track a new capstone covering Y", "I want to plan a project for Z") route to `@project-intake`, which asks clarifying questions about the project (technologies, purpose, where to ground research) and files a real issue with the `project` + `needs-triage` labels so the auto-add workflows place it on both the Projects Roadmap (board #13) and the Triage Queue (board #19). Once triaged and ready to publicise, `@projects-publishing` lands the card on `ms_security_projects.html`. Cert-shaped requests (a new certification or education-path goal — "study for SC-401", "track CompTIA CySA+ for Q3", "plan an exam path for AZ-500 → SC-500") route to `@cert-intake`, which researches the vendor exam requirements (skills outline, prerequisites, retirement notices) and files a real issue with the `certification` label so the tag-routing workflow places it on the Certification/Education Path board (#2); the agent then sets the board's Vendor, Exam Code, Start, and End fields. The `Board` label and `board-autoadd` workflow handle real issues filed outside the agent. All other shapes — features, chores, docs, ambiguous asks — route to `@request-intake`. If a specialized intake (`@bug-intake`, `@project-intake`, or `@cert-intake`) decides the request isn't its shape, it defers back to `@request-intake`. See [wiki/Terminology.md](../wiki/Terminology.md) for the Project (portfolio) vs Board (GitHub Projects v2) distinction.
+| Shape | Agent | Notes |
+|-------|-------|-------|
+| Bug ("X is broken", screenshot of broken UI) | `@bug-intake` | Bug-tracking board; defers to `@request-intake` if not actually a bug. |
+| New portfolio project / capstone / roadmap initiative | `@project-intake` | Drafts on Projects Roadmap board #13. After triage, `@projects-publishing` lands the card on `ms_security_projects.html`. |
+| New certification / education-path goal | `@cert-intake` | Researches vendor exam (skills, prereqs, retirement). Files with `certification` label → board #2. |
+| Anything else (feat / chore / docs / ambiguous) | `@request-intake` | Generic front door. Specialized intakes defer here if shape doesn't match. |
 
-Skip intake when:
+When in doubt, ask once: "Track this as an issue, or handle it inline?" Default to inline if the user named a file and an action.
 
-- The user is asking a question (answer directly).
-- The user is mid-flow on an existing issue or PR (continue that flow).
-- The user explicitly says `skip intake`, `just do it`, `quick fix`, or names a target file and asks for a direct edit.
-- The change is a typo, a single-line content tweak, or a comment edit (use direct edit + branch + PR; no issue needed).
+## Other entry points
 
-When in doubt, ask once: "Track this as an issue, or handle it inline?" Default to inline if the user already named a file and an action.
+- Publish a portfolio update → `/publish-update` or `@publish-manager`.
+- Security review of a PR → `/secure-code-review` or `@security-reviewer`.
+- Issues / Boards / Wiki ops via `gh` → `@repo-ops`.
+- Triage `needs-triage` queue → `@triage` (chat-only; one issue at a time; `apply` / `dismiss` / `edit:` / `cancel`).
+- Sweep stale artefacts (test outputs, `staging-inbox/`, merged branches) → `/repo-cleanup` or `@repo-cleanup`.
+
+See [wiki/Agents.md](../wiki/Agents.md) for the full catalog and handoff diagram.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,6 +25,9 @@
 | HTML page authoring | [.github/instructions/html-pages.instructions.md](instructions/html-pages.instructions.md) (auto-attaches to `*.html`) |
 | Wiki authoring | [.github/instructions/wiki-content.instructions.md](instructions/wiki-content.instructions.md) (auto-attaches to `wiki/**`) |
 | Workflow authoring | [.github/instructions/workflows.instructions.md](instructions/workflows.instructions.md) (auto-attaches to `.github/workflows/**`) |
+| PowerShell ops scripts | [.github/instructions/scripts-powershell.instructions.md](instructions/scripts-powershell.instructions.md) (auto-attaches to `scripts/**/*.ps1`) |
+| Playwright tests | [.github/instructions/tests-playwright.instructions.md](instructions/tests-playwright.instructions.md) (auto-attaches to `tests/**/*.ts`) |
+| Agent / prompt / instruction authoring | [.github/agents/README.md](agents/README.md), [.github/prompts/README.md](prompts/README.md) |
 | Cloud-agent contract | [AGENTS.md](../AGENTS.md) |
 | Folder map, full architecture | [wiki/Repo-Architecture.md](../wiki/Repo-Architecture.md) |
 | Full agent catalog + handoffs | [wiki/Agents.md](../wiki/Agents.md) |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,9 @@
 | PowerShell ops scripts | [.github/instructions/scripts-powershell.instructions.md](instructions/scripts-powershell.instructions.md) (auto-attaches to `scripts/**/*.ps1`) |
 | Playwright tests | [.github/instructions/tests-playwright.instructions.md](instructions/tests-playwright.instructions.md) (auto-attaches to `tests/**/*.ts`) |
 | Agent / prompt / instruction authoring | [.github/agents/README.md](agents/README.md), [.github/prompts/README.md](prompts/README.md) |
+| External best-practice URLs (MDN, OWASP, WCAG, GitHub docs, MS Learn) | [.github/instructions/grounding-sources.instructions.md](instructions/grounding-sources.instructions.md) |
 | Cloud-agent contract | [AGENTS.md](../AGENTS.md) |
+| Repo governance | [SECURITY.md](../SECURITY.md), [CONTRIBUTING.md](../CONTRIBUTING.md), [.github/CODEOWNERS](CODEOWNERS), [LICENSE](../LICENSE) |
 | Folder map, full architecture | [wiki/Repo-Architecture.md](../wiki/Repo-Architecture.md) |
 | Full agent catalog + handoffs | [wiki/Agents.md](../wiki/Agents.md) |
 

--- a/.github/instructions/grounding-sources.instructions.md
+++ b/.github/instructions/grounding-sources.instructions.md
@@ -1,0 +1,76 @@
+---
+description: "Canonical external best-practice URLs for grounding repo decisions. Load when reviewing PRs, drafting maturity gaps, validating workflow security, or citing best-practice sources. Not auto-attached — referenced from copilot-instructions.md and the maturity-scout / security-reviewer agents."
+---
+
+# Grounding sources
+
+When an agent or PR needs to cite "current best practice" for the static-portfolio domain, use these URLs as ground truth. Do not invent or paraphrase recommendations from training data — fetch the live page and link the section. Each URL is intentionally the **stable docs landing page**, not a deep-link, so agents resolve to the latest content.
+
+## Web platform — HTML, CSS, accessibility
+
+| Topic | Source |
+|---|---|
+| HTML semantics, elements, forms | <https://developer.mozilla.org/en-US/docs/Web/HTML> |
+| ARIA roles, states, properties | <https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA> |
+| WCAG 2.2 success criteria (target conformance: AA) | <https://www.w3.org/WAI/WCAG22/quickref/> |
+| WAI-ARIA Authoring Practices (patterns) | <https://www.w3.org/WAI/ARIA/apg/patterns/> |
+| Subresource Integrity (SRI) for CDN scripts | <https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity> |
+| Content Security Policy basics | <https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP> |
+
+## GitHub Actions security & operations
+
+| Topic | Source |
+|---|---|
+| Actions security hardening (top of stack) | <https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions> |
+| `permissions:` reference (least privilege) | <https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs> |
+| `pull_request_target` security model | <https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target> |
+| Pinning third-party actions to SHAs | <https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions> |
+| GITHUB_TOKEN permissions | <https://docs.github.com/en/actions/security-guides/automatic-token-authentication> |
+
+## GitHub repo & Pages governance
+
+| Topic | Source |
+|---|---|
+| Branch protection rules | <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches> |
+| GitHub Pages — building from a branch / Actions | <https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages> |
+| CODEOWNERS syntax | <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners> |
+| `SECURITY.md` policy | <https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository> |
+| Dependabot configuration | <https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file> |
+| CodeQL setup options | <https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning-with-codeql> |
+| Secret scanning + push protection | <https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning> |
+
+## GitHub Projects v2 (boards)
+
+| Topic | Source |
+|---|---|
+| Projects v2 overview | <https://docs.github.com/en/issues/planning-and-tracking-with-projects> |
+| GraphQL API for ProjectV2 | <https://docs.github.com/en/graphql/reference/objects#projectv2> |
+| `gh project` CLI reference | <https://cli.github.com/manual/gh_project> |
+
+## Application security (static-site scope)
+
+| Topic | Source |
+|---|---|
+| OWASP Top 10 (current) | <https://owasp.org/www-project-top-ten/> |
+| OWASP Cheat Sheets index | <https://cheatsheetseries.owasp.org/> |
+| OWASP HTML5 Security Cheat Sheet | <https://cheatsheetseries.owasp.org/cheatsheets/HTML5_Security_Cheat_Sheet.html> |
+
+## Microsoft technology grounding
+
+These ground the **content** of the portfolio pages (claims about Defender, Entra, Sentinel, Purview, etc.). When `@maturity-scout` runs `source:ms-learn`, fetch the relevant page below and compare against the live site copy.
+
+| Topic | Source |
+|---|---|
+| Microsoft Learn — Security documentation hub | <https://learn.microsoft.com/en-us/security/> |
+| Microsoft Defender for Cloud overview | <https://learn.microsoft.com/en-us/azure/defender-for-cloud/> |
+| Microsoft Sentinel documentation | <https://learn.microsoft.com/en-us/azure/sentinel/> |
+| Microsoft Entra ID documentation | <https://learn.microsoft.com/en-us/entra/> |
+| Microsoft Purview documentation | <https://learn.microsoft.com/en-us/purview/> |
+| Azure Security Benchmark | <https://learn.microsoft.com/en-us/security/benchmark/azure/> |
+
+## Usage rules
+
+- **Always fetch the live page** before citing — recommendations change. Do not rely on cached training data.
+- **Link to a heading anchor** when possible (`#section-id`), not just the page root.
+- **Cite once per finding** — agents should quote ≤2 sentences and link out, not mirror the source.
+- If a recommendation conflicts with a hard rule in `copilot-instructions.md`, the repo rule wins; file a maturity issue if the conflict looks unintentional.

--- a/.github/instructions/scripts-powershell.instructions.md
+++ b/.github/instructions/scripts-powershell.instructions.md
@@ -1,0 +1,78 @@
+---
+description: "Use when authoring or editing PowerShell ops scripts under scripts/. Covers strict-mode requirements, gh CLI flag-shape gotchas, Projects v2 token scope, and idempotency conventions."
+applyTo: "scripts/**/*.ps1"
+---
+
+# PowerShell ops script rules
+
+## Required header
+
+```powershell
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    One-line summary.
+.DESCRIPTION
+    What it does, when to run it, side effects.
+#>
+[CmdletBinding()]
+param( ... )
+$ErrorActionPreference = 'Stop'
+```
+
+- All scripts run on PowerShell 7+ (matches the GitHub Actions `windows-latest` and our local pwsh).
+- Use `[CmdletBinding()]` + typed `param()` blocks. No positional bareword args.
+- Always set `$ErrorActionPreference = 'Stop'` so a failed `gh` call aborts the script instead of silently continuing.
+- Prefer `-DryRun` switches for any script that mutates GitHub state (issues, labels, branch protection, project items).
+
+## `gh` CLI flag-shape gotchas (verified gh ≥ 2.90)
+
+These are easy to get wrong. The failure modes are silent or misleading — keep them straight.
+
+| Command | Correct shape | Wrong shape that fails silently or misleadingly |
+|---------|---------------|-------------------------------------------------|
+| `gh project item-add` | `<number> --owner <owner> --url <issue-or-pr-url>` | `--content-url` (removed in 2.x) |
+| `gh project item-create` | `<number> --owner <owner> --title '...' --body $bodyText` (read with `Get-Content -Raw`) | `--body-file` (does not exist on `item-create`; only on `gh issue create`) |
+| `gh project item-delete` | `<number> --owner <owner> --id <PVTI_...>` | `--project-id <PVT_...>` (only valid on `item-edit`, not `item-delete`) |
+| `gh project item-edit` | `--project-id <PVT_...> --id <PVTI_...> --field-id <PVTSSF_...> --single-select-option-id <...>` | mixing project number with `--project-id` |
+| `gh api` boolean fields | `@{ enabled = $true } | ConvertTo-Json | gh api ... --input -` | `-f enabled=true` (sends string `"true"` → 422) |
+
+When in doubt, run `gh <verb> <noun> --help` before guessing flags.
+
+## GitHub Projects v2 token scope
+
+- The default `GITHUB_TOKEN` in workflows **cannot** write Projects v2 fields. Use the repo secret `BUG_PROJECT_TOKEN` (classic PAT, `project` scope; `repo` if private).
+- **Fine-grained PATs do not work** for user-owned Projects v2. The "Projects" account permission is unreliable and fails with `Resource not accessible by personal access token`. Stick to classic PATs.
+- `BUG_PROJECT_TOKEN` is intentionally narrow: `project` scope only. It **cannot** mutate issue labels (`addLabelsToLabelable` requires `public_repo` or `repo`). Workflows that need both must split: probe with `BUG_PROJECT_TOKEN`, edit issue state with the default `secrets.GITHUB_TOKEN` + `permissions: issues: write`. Do **not** widen the PAT.
+
+## Listing project items — `item-list` is unreliable
+
+`gh project item-list <n> --owner <owner>` returns `totalCount: 0` even when items exist (verified gh 2.90.0, 2026-04). The same lag is reproducible across boards and during GitHub Projects v2 indexing incidents. Do not trust empty results.
+
+Canonical ground truth — query from the issue side:
+
+```powershell
+gh api graphql -f query='
+  query($owner:String!,$name:String!,$num:Int!){
+    repository(owner:$owner,name:$name){
+      issue(number:$num){ projectItems(first:20){ nodes{ project{ number title } } } }
+    }
+  }' -f owner=marcusjacobson -f name=portfolio -F num=$IssueNumber
+```
+
+## Idempotency
+
+- A script that adds an item to a board, applies a label, or syncs a config must be safe to re-run. Check existence before mutating; treat "already there" as success.
+- Branch protection (`apply-branch-protection.ps1`): only run after each required check has reported on `main` at least once, or GitHub rejects contexts that have never registered.
+
+## Required-status-check naming
+
+When updating `apply-branch-protection.ps1`'s required-context list:
+
+- Matrix jobs render as `<jobname> (<matrix-param>)`. Example: `analyze (javascript-typescript)`, **not** `analyze`.
+- A workflow with a `paths:` filter that sometimes doesn't run (e.g., `build` from `pages-deploy.yml` on docs-only PRs) **cannot** be a required context, or PRs deadlock waiting for a check that never registers.
+
+## Output
+
+- Use `Write-Host` for human-facing progress, `Write-Output` only for values you intend to be captured by callers.
+- Echo the resolved values (resolved owner/number, payload preview) before mutating, especially in `-DryRun` mode.

--- a/.github/instructions/tests-playwright.instructions.md
+++ b/.github/instructions/tests-playwright.instructions.md
@@ -1,0 +1,52 @@
+---
+description: "Use when authoring or editing Playwright test specs under tests/. Covers visual snapshot rules, axe accessibility scans, and the local http-server baseURL contract."
+applyTo: "tests/**/*.ts"
+---
+
+# Playwright test rules
+
+## Snapshot discipline
+
+- **Never edit `tests/visual/__snapshots__/` by hand.** Regenerate via `npm run test:visual:update` and commit the diff alongside the visual change that justified it.
+- Snapshot filenames embed `testInfo.project.name` (`desktop`, `mobile`, `tablet`). When adding a new viewport, update `tests/playwright.config.ts` projects — do not hand-name snapshots.
+- Visual specs live in `tests/visual/`; one `for (const page of PAGES)` loop per spec keeps the snapshot set predictable.
+
+## Page list source of truth
+
+Both `tests/visual/pages.spec.ts` and `tests/a11y/axe.spec.ts` enumerate the top-level `*.html` files. The a11y spec discovers them at runtime (`readdirSync(repoRoot).filter(*.html)`); the visual spec uses a hard-coded array. When adding a new top-level page, update **both**:
+
+1. Append the filename to the `PAGES` array in `tests/visual/pages.spec.ts`.
+2. Run `npm run test:visual:update` to seed snapshots for the new page across all projects.
+3. The a11y spec picks the page up automatically — no edit needed.
+
+## baseURL contract
+
+- Tests load pages by relative filename (`pw.goto('index.html')`). The `baseURL` is set by `tests/playwright.config.ts` (and the maturity-scan workflow boots a local `http-server` on `:8080` before invoking the spec).
+- Do **not** hardcode `http://localhost:8080` or absolute URLs in specs — they break under different ports and the GitHub Pages preview environment.
+
+## Wait conditions
+
+- Use `await pw.waitForLoadState('networkidle')` before screenshots so external fonts/CDN preconnects settle. `domcontentloaded` is too early; `load` misses lazy-loaded fonts.
+- Avoid `page.waitForTimeout()` for stabilization — it's flaky across CI runners. Wait on a real signal (selector, network state, font readiness).
+
+## axe accessibility scans
+
+- The a11y spec writes JSON results to `.axe-pw-reports/<page-slug>.json` for the workflow to aggregate. Do not change that path without updating `.github/workflows/maturity-scan.yml`.
+- Tag set is `['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa']` — keep aligned with the `@axe-core/cli` (Option B) tag set so cross-scan rule comparisons stay valid.
+- New rules or tag changes belong in a follow-up issue against board #15 (Portfolio Maturity), not buried in an unrelated PR.
+
+## Imports
+
+- Prefer named imports from `@playwright/test` (`import { test, expect } from '@playwright/test'`).
+- Node built-ins use the `node:` prefix (`import { mkdirSync } from 'node:fs'`).
+- Don't add new runtime dependencies for tests — everything must work from the existing `package.json` devDependencies.
+
+## Local run
+
+```pwsh
+npm ci
+npm run test:visual          # asserts against existing snapshots
+npm run test:visual:update   # regenerates snapshots (only sanctioned way)
+```
+
+The a11y spec runs in CI via `maturity-scan.yml` — it is not part of the default `npm test` flow because it requires the http-server side-car.

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -39,3 +39,52 @@ applyTo: ".github/workflows/**"
 - Unpinned `uses: actions/checkout@main` — pin to `@v4` minimum.
 - Overlapping deploy workflows without `concurrency:` — causes race conditions on Pages.
 - Using `pull_request_target` to comment on PRs when `pull_request` + `permissions: pull-requests: write` works.
+
+## Tested gotchas (verified in this repo)
+
+### Heredoc inside `run: |` breaks the YAML block scalar
+
+A `cat <<EOF ... EOF` heredoc whose body has any column-0 line will terminate the YAML block scalar early. The workflow registers as active, but every push fails with `Invalid workflow file ... line N` and `gh workflow run` returns a misleading HTTP 422 `Workflow does not have workflow_dispatch trigger`.
+
+Don't:
+
+```yaml
+- name: File issue
+  run: |
+    BODY=$(cat <<EOF
+    ## Source
+    Some text at column 0.   # ← terminates the block scalar
+    EOF
+    )
+```
+
+Do — extract the body to a template under `.github/workflows/templates/` and substitute placeholders:
+
+```yaml
+- name: File issue
+  run: |
+    read_body () { sed "s|__PATH__|$1|g" .github/workflows/templates/repo-hygiene-issue-body.md; }
+    BODY=$(read_body "$path")
+```
+
+See `maturity-scan.yml` (`read_body` helper, ~line 58) for the working pattern.
+
+### Path-filtered jobs cannot be required PR contexts
+
+A workflow with a `paths:` filter that sometimes does not run (e.g., the `build` job in `pages-deploy.yml` on a docs-only PR) **cannot** be a required status check, or PRs deadlock waiting for a check that never registers. Either drop the `paths:` filter (run always, fast-exit when irrelevant) or remove the context from `apply-branch-protection.ps1`'s required list.
+
+### Matrix job context names include the matrix value
+
+`actions/codeql-action`'s `analyze` job renders as `analyze (javascript-typescript)` — required-context strings in branch protection must match the rendered name including the matrix params in parens, not the bare job name.
+
+### `gh api` boolean serialization
+
+`-f enabled=true` sends the **string** `"true"` and a JSON-typed boolean field returns 422. Use `ConvertTo-Json` and pipe to `--input -`:
+
+```pwsh
+@{ enabled = $true } | ConvertTo-Json | gh api ... --input -
+```
+
+## Best-practice sources
+
+When auditing a workflow against external recommendations (during PR review or `@maturity-scout` runs), ground in the canonical URLs catalogued in [grounding-sources.instructions.md](grounding-sources.instructions.md) — Actions security hardening, `permissions:` reference, third-party action pinning, and `pull_request_target` security model.


### PR DESCRIPTION
## Summary

Trimmed `.github/copilot-instructions.md` from 88 → 53 lines (~60% reduction) to minimize always-on context-window usage in VS Code Copilot Chat. Every chat turn loads this file; everything else stays out of the default context until referenced.

## Audit findings

| File class | Loaded when | Action |
|---|---|---|
| `.github/copilot-instructions.md` | every chat turn | **slimmed** (this PR) |
| `AGENTS.md` | every cloud-agent run only (not chat) | leave (82 lines, resolver contract) |
| `.github/instructions/*.instructions.md` | path match via `applyTo` glob | leave (already scoped, 32–51 lines) |
| `.github/agents/*.agent.md` | only when the user invokes `@agent` | leave (size irrelevant to default context) |
| `.github/prompts/*.prompt.md` | only when the user invokes `/slash` | leave (same as above) |

## What was removed from the always-on file

- **Site authoring section** — duplicates `html-pages.instructions.md` which auto-attaches on `*.html`.
- **Tooling layout table** — covered in more detail by `wiki/Repo-Architecture.md`.
- **Verified-commands prose table** — collapsed to a single inline list.
- **""When working as cloud agent"" section** — chat is never the cloud agent; `AGENTS.md` is the canonical place.
- **Intake flow prose paragraph** (~250 words) — collapsed to a 4-row routing table; full detail still lives in `wiki/Agents.md`.

## What was preserved (critical for every turn)

- Hard rules (no direct push to `main`, snapshot regen, action pinning, `permissions:` requirement, secrets, `alt` attrs, commit/PR style).
- Verified shell commands.
- Pointer table to scoped instruction files, `AGENTS.md`, and the architecture/agents wiki pages.
- Intake routing matrix + skip-intake conditions.
- Other entry points (`/publish-update`, `@security-reviewer`, `@repo-ops`, `@triage`, `/repo-cleanup`).

## Tested

- Verified all internal links resolve (all targets exist on disk).
- No agent or prompt files modified, so no behavioral change to `@`- or `/`-invoked flows.
- Required PR checks (lint, lychee, CodeQL, gitleaks) should pass — change is docs-only.