### PR TITLE
Add PR-side staging preview via reusable pages-build workflow

### DIFF
--- a/.github/agents/publish-manager.agent.md
+++ b/.github/agents/publish-manager.agent.md
@@ -13,6 +13,7 @@ You are the **Publish Manager** for the portfolio site. Your job is to take a se
 - DO NOT force-push.
 - DO NOT update visual snapshots without explicit user confirmation.
 - DO NOT merge PRs.
+- DO NOT recommend merge until the user has previewed the rendered build artifact locally and confirmed it visually. The PR-side `pages-build` workflow exists specifically to enable this gate.
 
 ## Approach
 
@@ -21,7 +22,8 @@ You are the **Publish Manager** for the portfolio site. Your job is to take a se
 3. Run `npm run lint`. Fix mechanically obvious issues (quoting, indentation) and re-run; otherwise stop and report.
 4. Run `npm run test:visual`. On failure, summarize the diff, ask the user whether to update baselines.
 5. Commit (imperative subject ≤72 chars), push, `gh pr create` with the standard template.
-6. `gh pr checks --watch`, then report the required reviewers.
+6. `gh pr checks --watch`. Once required checks (including `build` from `pages-build.yml`) are green, run `./scripts/preview-pr.ps1 -Pr <N>` locally and ask the user to click through the served site at `http://localhost:8080/` before approving.
+7. Report PR URL, check status, and the required reviewer step. Do not advise merge until the user signs off on the preview.
 
 ## Output format
 

--- a/.github/workflows/pages-build.yml
+++ b/.github/workflows/pages-build.yml
@@ -62,12 +62,16 @@ jobs:
       - name: Render CHANGELOG.md into changelog.html
         # Convert the curated CHANGELOG.md into HTML and inject it into the
         # `<!-- CHANGELOG_BODY -->...<!-- /CHANGELOG_BODY -->` placeholder.
-        # pandoc is preinstalled on ubuntu-latest GitHub runners.
         run: |
           set -euo pipefail
           if [ ! -f CHANGELOG.md ]; then
             echo "CHANGELOG.md missing; skipping changelog render."
             exit 0
+          fi
+          # pandoc is no longer preinstalled on ubuntu-latest; install on demand.
+          if ! command -v pandoc >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends pandoc
           fi
           pandoc --from=gfm --to=html5 CHANGELOG.md -o /tmp/changelog-body.html
           # Drop the leading "# Changelog" h1 — the page header already provides it.

--- a/.github/workflows/pages-build.yml
+++ b/.github/workflows/pages-build.yml
@@ -1,0 +1,111 @@
+name: Build Pages
+
+# Renders the static portfolio (Last-updated stamps + CHANGELOG injection) and
+# uploads the result as a downloadable artifact. Runs on every PR so the
+# maintainer can preview the built site locally before merge via
+# `scripts/preview-pr.ps1`. Also reusable from `pages-deploy.yml` on push to
+# `main`, where it additionally produces the special `github-pages` artifact
+# that `actions/deploy-pages` consumes.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_call:
+    inputs:
+      upload-pages-artifact:
+        description: "Also upload the special github-pages artifact for actions/deploy-pages."
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # Cancel superseded PR builds; never cancel a build feeding a deploy.
+  group: pages-build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Need full history so `git log -1` can resolve the last commit
+          # that touched each page when injecting "Last updated" timestamps.
+          fetch-depth: 0
+
+      - name: Setup Pages
+        if: ${{ inputs.upload-pages-artifact }}
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Inject per-page Last updated timestamps
+        # Replace the `<!-- LAST_UPDATED -->...<!-- /LAST_UPDATED -->` placeholder
+        # in each root HTML page with the date (YYYY-MM-DD) of the last commit
+        # that touched that file on the current ref. The rendered HTML is only
+        # written into the build artifact — never committed back to main.
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for f in *.html; do
+            ts=$(git log -1 --format=%cs -- "$f" 2>/dev/null || true)
+            if [ -z "$ts" ]; then
+              ts=$(date -u +%Y-%m-%d)
+            fi
+            perl -i -pe "s|<!-- LAST_UPDATED -->.*?<!-- /LAST_UPDATED -->|<!-- LAST_UPDATED -->${ts}<!-- /LAST_UPDATED -->|g" "$f"
+            echo "  $f -> $ts"
+          done
+
+      - name: Render CHANGELOG.md into changelog.html
+        # Convert the curated CHANGELOG.md into HTML and inject it into the
+        # `<!-- CHANGELOG_BODY -->...<!-- /CHANGELOG_BODY -->` placeholder.
+        # pandoc is preinstalled on ubuntu-latest GitHub runners.
+        run: |
+          set -euo pipefail
+          if [ ! -f CHANGELOG.md ]; then
+            echo "CHANGELOG.md missing; skipping changelog render."
+            exit 0
+          fi
+          pandoc --from=gfm --to=html5 CHANGELOG.md -o /tmp/changelog-body.html
+          # Drop the leading "# Changelog" h1 — the page header already provides it.
+          perl -0777 -i -pe 's|<h1[^>]*>.*?</h1>\s*||s' /tmp/changelog-body.html
+          python3 scripts/render_changelog.py /tmp/changelog-body.html
+
+      - name: Stage rendered site
+        # Copy the rendered tree into _site/ so artifact uploads carry only
+        # what would be served, not the whole repo (tests, scripts, .github).
+        run: |
+          set -euo pipefail
+          mkdir -p _site
+          # Root HTML pages and assets that ship to the live site.
+          shopt -s nullglob
+          cp -v *.html _site/
+          # Copy any top-level static assets if they exist (none today, but
+          # keeps the workflow forward-compatible).
+          for d in assets images img css js; do
+            if [ -d "$d" ]; then
+              cp -rv "$d" "_site/$d"
+            fi
+          done
+
+      - name: Upload preview artifact (downloadable)
+        # Always upload a regular workflow artifact named `site-preview` so
+        # `scripts/preview-pr.ps1` can fetch and serve it locally regardless
+        # of whether this run is feeding a deploy.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: site-preview
+          path: _site
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Upload Pages artifact (deploy)
+        # Only when invoked by the deploy workflow; produces the special
+        # `github-pages` artifact that `actions/deploy-pages` picks up.
+        if: ${{ inputs.upload-pages-artifact }}
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: _site

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,5 +1,10 @@
 name: Deploy GitHub Pages
 
+# Promotes a freshly-built site to the live `github-pages` environment. The
+# render logic lives in `pages-build.yml` (reusable workflow) so PR previews
+# and prod deploys go through identical steps. This workflow runs only on
+# pushes to `main` and on manual dispatch — never on PRs.
+
 on:
   push:
     branches: [main]
@@ -16,56 +21,13 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Reuse the PR-side render steps, but request the special
+    # `github-pages` artifact that `actions/deploy-pages` consumes.
+    uses: ./.github/workflows/pages-build.yml
     permissions:
       contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          # Need full history so `git log -1` can resolve the last commit
-          # that touched each page when injecting "Last updated" timestamps.
-          fetch-depth: 0
-
-      - name: Setup Pages
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-
-      - name: Inject per-page Last updated timestamps
-        # Replace the `<!-- LAST_UPDATED -->...<!-- /LAST_UPDATED -->` placeholder
-        # in each root HTML page with the date (YYYY-MM-DD) of the last commit
-        # that touched that file on the current ref. The rendered HTML is only
-        # written into the build artifact — never committed back to main.
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          for f in *.html; do
-            ts=$(git log -1 --format=%cs -- "$f" 2>/dev/null || true)
-            if [ -z "$ts" ]; then
-              ts=$(date -u +%Y-%m-%d)
-            fi
-            perl -i -pe "s|<!-- LAST_UPDATED -->.*?<!-- /LAST_UPDATED -->|<!-- LAST_UPDATED -->${ts}<!-- /LAST_UPDATED -->|g" "$f"
-            echo "  $f -> $ts"
-          done
-
-      - name: Render CHANGELOG.md into changelog.html
-        # Convert the curated CHANGELOG.md into HTML and inject it into the
-        # `<!-- CHANGELOG_BODY -->...<!-- /CHANGELOG_BODY -->` placeholder.
-        # pandoc is preinstalled on ubuntu-latest GitHub runners.
-        run: |
-          set -euo pipefail
-          if [ ! -f CHANGELOG.md ]; then
-            echo "CHANGELOG.md missing; skipping changelog render."
-            exit 0
-          fi
-          pandoc --from=gfm --to=html5 CHANGELOG.md -o /tmp/changelog-body.html
-          # Drop the leading "# Changelog" h1 — the page header already provides it.
-          perl -0777 -i -pe 's|<h1[^>]*>.*?</h1>\s*||s' /tmp/changelog-body.html
-          python3 scripts/render_changelog.py /tmp/changelog-body.html
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-        with:
-          path: .
+    with:
+      upload-pages-artifact: true
 
   deploy:
     needs: build

--- a/scripts/preview-pr.ps1
+++ b/scripts/preview-pr.ps1
@@ -1,0 +1,76 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Download the rendered site artifact from a PR and serve it on localhost.
+.DESCRIPTION
+    Resolves the most recent successful `pages-build.yml` run for the given
+    PR, downloads its `site-preview` artifact, unpacks it under
+    `staging-inbox/pr-<N>/`, and starts `npx http-server` on the requested
+    port so the maintainer can click through the built site before merge.
+
+    Requires `gh` (authenticated), Node.js (for `npx http-server`), and the
+    PR's `pages-build` check to have completed at least once.
+.PARAMETER Pr
+    Pull request number to preview.
+.PARAMETER Port
+    Local port for the preview server. Default 8080.
+.PARAMETER NoServe
+    Download and unpack only; skip launching the server. Useful for CI
+    smoke tests.
+.EXAMPLE
+    ./scripts/preview-pr.ps1 -Pr 312
+    Downloads PR #312's preview and serves http://localhost:8080/.
+.EXAMPLE
+    ./scripts/preview-pr.ps1 -Pr 312 -Port 9000
+    Same, on a different port.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][int]$Pr,
+    [int]$Port = 8080,
+    [switch]$NoServe
+)
+$ErrorActionPreference = 'Stop'
+
+# 1. Resolve the PR's head SHA so we fetch the matching build run.
+$headSha = gh pr view $Pr --json headRefOid --jq '.headRefOid' 2>$null
+if (-not $headSha) {
+    throw "Could not resolve PR #$Pr. Is it open and visible to your gh auth?"
+}
+
+# 2. Find the most recent successful pages-build.yml run for that SHA.
+$run = gh run list `
+    --workflow pages-build.yml `
+    --commit $headSha `
+    --status success `
+    --limit 1 `
+    --json databaseId,headBranch,createdAt `
+    --jq '.[0]' | ConvertFrom-Json
+if (-not $run) {
+    throw "No successful pages-build run found for PR #$Pr (sha $headSha). Wait for the check to finish, then retry."
+}
+Write-Host "Found build run $($run.databaseId) on $($run.headBranch) (created $($run.createdAt))." -ForegroundColor Cyan
+
+# 3. Download artifact into staging-inbox/pr-<N>/.
+$dest = Join-Path -Path (Get-Location) -ChildPath "staging-inbox/pr-$Pr"
+if (Test-Path $dest) {
+    Write-Host "Refreshing $dest." -ForegroundColor DarkGray
+    Remove-Item -Recurse -Force $dest
+}
+New-Item -ItemType Directory -Path $dest -Force | Out-Null
+gh run download $run.databaseId --name site-preview --dir $dest
+Write-Host "Artifact unpacked to $dest." -ForegroundColor Green
+
+if ($NoServe) {
+    Write-Host "Skipping server (-NoServe). Preview directory: $dest"
+    return
+}
+
+# 4. Serve. http-server is small, transitive-free, and ships with npx.
+Write-Host "Serving on http://localhost:$Port/  (Ctrl+C to stop)" -ForegroundColor Cyan
+Push-Location $dest
+try {
+    npx --yes http-server -p $Port -c-1 .
+} finally {
+    Pop-Location
+}

--- a/tests/lychee.toml
+++ b/tests/lychee.toml
@@ -42,6 +42,9 @@ exclude = [
     "^https?://github\\.com/marcusjacobson/portfolio/blob/main/AGENTS\\.md$",
     # Fresh agent file added in PR #297 (#288) — 404 until merged to main.
     "^https?://github\\.com/marcusjacobson/portfolio/blob/main/\\.github/agents/cert-intake\\.agent\\.md",
+    # Fresh files added in PR #312 (#311) — 404 until merged to main.
+    "^https?://github\\.com/marcusjacobson/portfolio/blob/main/\\.github/workflows/pages-build\\.yml",
+    "^https?://github\\.com/marcusjacobson/portfolio/blob/main/scripts/preview-pr\\.ps1",
     # LinkedIn returns 404 to unauthenticated bots (intermittent). Public profile is verified manually.
     "^https?://(www\\.)?linkedin\\.com/in/",
 ]

--- a/wiki/Deployment-Rules.md
+++ b/wiki/Deployment-Rules.md
@@ -42,7 +42,7 @@ Other settings enforced by the script:
 
 ## Pages deploy contract
 
-Publishing to <https://marcusjacobson.github.io/portfolio/> is owned exclusively by [`pages-deploy.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/workflows/pages-deploy.yml).
+Publishing to <https://marcusjacobson.github.io/portfolio/> is owned exclusively by [`pages-deploy.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/workflows/pages-deploy.yml), which delegates rendering to the reusable [`pages-build.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/workflows/pages-build.yml).
 
 | Aspect | Value |
 |--------|-------|
@@ -51,9 +51,17 @@ Publishing to <https://marcusjacobson.github.io/portfolio/> is owned exclusively
 | Permissions | `contents: read`, `pages: write`, `id-token: write` (OIDC for `actions/deploy-pages`). |
 | Secrets | None. Uses `GITHUB_TOKEN` via OIDC. |
 | Concurrency | `group: pages`, `cancel-in-progress: false` — in-flight deploys finish before the next starts, preventing torn artifacts. |
-| Jobs | `build` uploads the repo root as a Pages artifact; `deploy` consumes it via [`actions/deploy-pages`](https://github.com/actions/deploy-pages). |
+| Jobs | `build` calls `pages-build.yml` with `upload-pages-artifact: true` to render `_site/` and emit the special `github-pages` artifact; `deploy` consumes it via [`actions/deploy-pages`](https://github.com/actions/deploy-pages). |
 
 Because `pages-deploy.yml` only fires on `push` to `main`, it never produces a status check on a PR. That is by design: the merge gates above already protect `main`, and Pages publishes after merge.
+
+## Staging preview gate (PR-side)
+
+[`pages-build.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/workflows/pages-build.yml) runs on every PR to `main` and on `workflow_call` from the deploy pipeline. The PR-side run uploads the rendered site as a `site-preview` workflow artifact (14-day retention), enabling a hard merge gate:
+
+- Rule: **no content PR is merged before the maintainer fetches the artifact via [`scripts/preview-pr.ps1`](https://github.com/marcusjacobson/portfolio/blob/main/scripts/preview-pr.ps1) and clicks through the rendered site locally.** This is why PR-side rendering exists.
+- The [`@publish-manager`](Agents) agent enforces this: it refuses to advise merge without preview confirmation. See [Agents](Agents) for the full handoff.
+- The reusable workflow runs identical render steps in both the PR and deploy paths, so a green preview is a faithful representation of what will go live.
 
 ## Wiki deploy contract
 

--- a/wiki/GitHub-Pages-Publishing.md
+++ b/wiki/GitHub-Pages-Publishing.md
@@ -77,3 +77,21 @@ if (typeof sendPrompt === 'undefined') {
 ```
 
 **Custom domain** — add a `CNAME` file to the repo root with your domain, then configure DNS to point to `marcusjacobson.github.io`.
+
+---
+
+## Staging preview (PR-side)
+
+There is no externally-hosted staging URL. Instead, every PR runs the same render pipeline as production via the reusable [`pages-build.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/workflows/pages-build.yml) workflow and uploads the rendered tree as a downloadable `site-preview` artifact (14-day retention).
+
+Before merging a content PR, fetch and serve the artifact locally:
+
+```powershell
+./scripts/preview-pr.ps1 -Pr <number>
+```
+
+The script downloads the latest successful `pages-build` artifact for the PR's head SHA, unpacks it under `staging-inbox/pr-<N>/`, and starts `npx http-server` on `http://localhost:8080/`. Click through the four portfolio pages, the changelog, and any newly added pages before approving the merge.
+
+The [`@publish-manager`](Agents) agent treats this preview step as a hard gate: it will not advise merging a content PR until the maintainer signs off on the local preview.
+
+The deploy pipeline ([`pages-deploy.yml`](https://github.com/marcusjacobson/portfolio/blob/main/.github/workflows/pages-deploy.yml)) calls the same reusable build on push to `main` and feeds the result into [`actions/deploy-pages`](https://github.com/actions/deploy-pages), so PR previews and the live site are bit-identical.


### PR DESCRIPTION
## Summary

Phase 1 of #311 — adds a PR-side staging preview to the Pages publish pipeline so the maintainer can review rendered content before it goes live.

**Approach**
- New reusable workflow `.github/workflows/pages-build.yml` runs on every PR (and via `workflow_call` from deploy). Renders the site into `_site/`, uploads it as a downloadable workflow artifact `site-preview` (14-day retention), and additionally uploads the special `github-pages` artifact when called by the deploy pipeline.
- `.github/workflows/pages-deploy.yml` slims down to a thin caller: `push:main` triggers `pages-build.yml` with `upload-pages-artifact: true`, then `actions/deploy-pages` ships it. PR previews and prod deploys now run identical render steps.
- New `scripts/preview-pr.ps1` fetches a PR''s `site-preview` artifact via `gh run download` and serves it on `http://localhost:8080/` via `npx http-server`. Output lands under `staging-inbox/pr-<N>/` (already gitignored).
- `@publish-manager` agent gains a hard preview-before-merge gate (refuses to advise merge until preview is confirmed).
- `wiki/GitHub-Pages-Publishing.md` adds a "Staging preview (PR-side)" section. `wiki/Deployment-Rules.md` updates the Pages deploy contract row and adds a "Staging preview gate" section.

## Acceptance criteria addressed

- [x] `pages-build.yml` runs on every PR and uploads the rendered Pages artifact.
- [x] `pages-deploy.yml` only runs on push to `main` and consumes the build artifact via `workflow_call`.
- [x] One-command preview flow: `./scripts/preview-pr.ps1 -Pr <N>`.
- [x] `publish-manager.agent.md` references the preview gate and refuses merge without confirmation.
- [x] `wiki/GitHub-Pages-Publishing.md` and `wiki/Deployment-Rules.md` describe the staging tier.

## Deferred (follow-up issues recommended)

- [ ] **Branch protection** — adding `build` (from `pages-build.yml`) to the required-context list. GitHub rejects required-context strings that have never been seen on `main`, so this must wait for at least one successful run on `main` post-merge, then a follow-up to update `scripts/apply-branch-protection.ps1`. Filing as a separate p2.
- [ ] `issue-resolver.agent.md` and `repo-cleanup.agent.md` updates (resolver: don''t merge content PRs without preview confirmation; cleanup: sweep stale `site-preview` artifacts >14 days).
- [ ] Optional `staging-reviewer.agent.md` and `preview-pr.prompt.md` for chat-discoverable preview flow.
- [ ] One-line pointers in `.github/copilot-instructions.md` and `AGENTS.md`.
- [ ] **Phase 2 hosting decision** (live staging URL): 2a sibling-repo Pages, 2b Azure SWA preview environments, 2c `staging` branch subpath, or skip. To be decided after Phase 1 has bedded in.

## Validation

- `npm run lint` — clean.
- YAML parse — both workflow files load with `yaml.safe_load`.
- PowerShell parse — `preview-pr.ps1` parses with no errors via `[Parser]::ParseFile`.
- The new `pages-build` job will register a `build` check on this PR for the first time; that run validates the reusable workflow plumbing.

## Tested checklist

- [x] Lint pass
- [x] YAML/PS syntax check
- [ ] `pages-build` check green on this PR (will be verified after push)
- [ ] Manual `./scripts/preview-pr.ps1 -Pr <this-PR>` smoke test (will be run after the build check completes)

Refs #311
