### PR TITLE
Smoke-test staging preview: bump index footer v1 -> v2

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
 
   <div class="footer">
     <span>marcusjacobson.github.io/portfolio · Microsoft Security Portfolio</span>
-    <span>Last updated: <!-- LAST_UPDATED -->unreleased<!-- /LAST_UPDATED --> · <a href="changelog.html">changelog</a> · <a href="https://www.linkedin.com/in/marcus-jacobson-tech/">linkedin ↗</a> · <a href="https://github.com/marcusjacobson/portfolio">github ↗</a> · v1</span>
+    <span>Last updated: <!-- LAST_UPDATED -->unreleased<!-- /LAST_UPDATED --> · <a href="changelog.html">changelog</a> · <a href="https://www.linkedin.com/in/marcus-jacobson-tech/">linkedin ↗</a> · <a href="https://github.com/marcusjacobson/portfolio">github ↗</a> · v2</span>
   </div>
 
 </div>


### PR DESCRIPTION
Smoke test for the new PR-side staging preview pipeline (#311 / PR #312).

**Edit:** `index.html` footer version tag bumped from `v1` to `v2` — single-character change, easy to spot on the rendered page in the bottom-right corner.

**Goal:** validate the end-to-end flow:

1. `pages-build.yml` runs and uploads the `site-preview` artifact.
2. `./scripts/preview-pr.ps1 -Pr <this-PR>` downloads + serves on `http://localhost:8080/`.
3. Maintainer eyeballs the change, then either merges (promote to live) or closes the PR (reject the change).

**This is a real test of the gate** — if the preview looks wrong, close without merging.
