### PR TITLE
chore: advance wiki-sync cursor to c4b6673

### DIFF
--- a/.copilot-tracking/wiki-sync-state.json
+++ b/.copilot-tracking/wiki-sync-state.json
@@ -1,10 +1,16 @@
 {
   "$schema": "./wiki-sync-state.schema.json",
-  "lastProcessedSha": "71686b2487b09bff88e8696c94580751981590a2",
-  "lastRunAt": "2026-05-01T22:15:00Z",
+  "lastProcessedSha": "c4b6673d0b223fa010105aaded4ce5d7e7b15682",
+  "lastRunAt": "2026-05-03T20:32:52Z",
   "lastBatchSummary": {
-    "filed": [300, 301, 302, 303],
+    "filed": [
+      315,
+      317,
+      318
+    ],
     "deferred": [],
-    "cancelled": []
+    "cancelled": [
+      316
+    ]
   }
 }


### PR DESCRIPTION
Advances the wiki-sync cursor from `71686b2` to `c4b6673` after the 2026-05-03 detection run.

## Batch summary

- filed: #315, #317, #318 (all on board #16, Phase/Priority/Size set)
- deferred: none
- cancelled: #316 (terminal-echo lag duplicate of #315; closed not-planned)

Routing table: v1.
