### PR TITLE
cert strategy: promote CCAP + Kusto III; add LinkedIn-only note

### DIFF
--- a/certification_strategy.html
+++ b/certification_strategy.html
@@ -206,8 +206,8 @@ body{background:var(--gray-bg);color:var(--text);font-family:'Georgia',serif;min
   <div class="posture">
     <div class="posture-cell good">
       <p class="posture-label">Active credentials</p>
-      <p class="posture-value">11</p>
-      <p class="posture-sub">industry certs, not badges</p>
+      <p class="posture-value">13</p>
+      <p class="posture-sub">12 certs + 1 skill badge</p>
     </div>
     <div class="posture-cell warn">
       <p class="posture-label">Lapsed / superseded</p>
@@ -308,6 +308,15 @@ body{background:var(--gray-bg);color:var(--text);font-family:'Georgia',serif;min
       </div>
 
       <div class="cert-row">
+        <span class="cert-badge held">CCAP</span>
+        <div class="cert-info">
+          <p class="cert-name">CompTIA Cloud Admin Professional (Stackable)</p>
+          <p class="cert-desc">Composite stackable credential aggregating Cloud+ and adjacent cloud administration coursework. Surviving CompTIA stackable after the Oct 2024 lapse of CSCP and CSIS — kept on the held roster as the active stackable companion to the standalones.</p>
+          <p class="cert-meta ok">Active · Expires May 2027</p>
+        </div>
+      </div>
+
+      <div class="cert-row">
         <span class="cert-badge held">ITIL Foundation</span>
         <div class="cert-info">
           <p class="cert-name">ITIL 4 Foundation</p>
@@ -331,6 +340,15 @@ body{background:var(--gray-bg);color:var(--text);font-family:'Georgia',serif;min
           <p class="cert-name">Microsoft Certified: AI Transformation Leader</p>
           <p class="cert-desc">Strategy-tier credential (exam AB-731) covering AI governance, adoption operating models, risk management, and aligning AI investments to business outcomes. Pairs with AB-730 to round out an AI advisory baseline — directly relevant to Security Copilot program design and DSPM for AI conversations with leadership audiences.</p>
           <p class="cert-meta ok">Active · Issued Mar 2026 · 1-year renewal</p>
+        </div>
+      </div>
+
+      <div class="cert-row">
+        <span class="cert-badge held">Kusto III</span>
+        <div class="cert-info">
+          <p class="cert-name">Microsoft Kusto Detective III</p>
+          <p class="cert-desc">Highest rank in the Microsoft Kusto Detective KQL challenge series. Skill badge (Credly) rather than a vendor exam — practical evidence of Sentinel-relevant KQL depth ahead of SC-200 formalising the same content.</p>
+          <p class="cert-meta ok">Active · Issued Mar 2025 · No expiry</p>
         </div>
       </div>
 
@@ -613,6 +631,7 @@ body{background:var(--gray-bg);color:var(--text);font-family:'Georgia',serif;min
     <p>Certifications answer a narrow question: <strong>can this person demonstrate baseline competency on a vendor's platform?</strong> They don't answer whether an engagement can be led, a CISO advised, or an architecture designed that actually holds up in a complex environment. At Senior Consultant level, <em>platform competency is assumed</em> — what clients are evaluating is judgment, communication, and whether the experience maps to their problem.</p>
     <p>The certification strategy here isn't accumulation — it's filling the specific gaps that matter for the Microsoft security stack (SC-300, SC-401, SC-500), then pursuing SC-100 when the work already reflects the seniority level it signals. <strong>CCSP and CISSP are horizon credentials tied to client type and seniority, not checkboxes.</strong></p>
     <p>The AZ-500 + AZ-400 combination is unusual in security consulting profiles — most security practitioners don't hold DevOps Engineer Expert. That combination signals platform depth that goes beyond advisory. Note that AZ-500 retires Aug 31, 2026 — SC-500 is a replacement exam, not a renewal, and is planned accordingly.</p>
+    <p>A small number of pre-pivot foundation credentials remain visible on the LinkedIn profile but are intentionally not portfolio-claimed here. <strong>CompTIA Project+</strong> is the current example. The cert was earned during the deliberate-build phase before the security pivot consolidated; LinkedIn renders it as part of the deliberate-build signal a recruiter skim can see, while this portfolio scopes the <em>Currently held</em> roster to credentials that actively support the Microsoft security stack and the Principal-track architecture direction. The asymmetry is intentional — resume and external tailoring follow the portfolio scope, not the LinkedIn render.</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Promote **CompTIA CCAP (Stackable)** and **Microsoft Kusto Detective III** into the *Currently held* column of `certification_strategy.html`.
- Update the Active credentials posture cell: count 11 -> 13, sub-text now reads `12 certs + 1 skill badge` (Kusto III is the skill badge).
- Add a 4th paragraph to the Philosophy section documenting the LinkedIn-vs-portfolio asymmetry; **CompTIA Project+** named as the current LinkedIn-only rendering exception.

## Edits (4 surgical regions)
1. Posture summary cell (`Active credentials`) - count and sub-text.
2. New `cert-row` for **CCAP Stackable** inserted after the A+ block.
3. New `cert-row` for **Microsoft Kusto Detective III** inserted after the AB-731 block.
4. New `<p>` appended to the `.philosophy` block explaining LinkedIn vs portfolio scope.

Diff scope: **1 file, 21 insertions / 2 deletions**. No edits outside the four regions above.

## Test plan
- [ ] 4 required status checks pass on this branch
- [ ] Preview build renders posture cell as `13 / 12 certs + 1 skill badge`
- [ ] CCAP Stackable row visible in *Currently held*, between A+ and ITIL Foundation
- [ ] Kusto Detective III row visible in *Currently held*, between AB-731 and SC-300 prep
- [ ] Philosophy section shows 4 paragraphs, last one references Project+ and the LinkedIn-only rendering