### PR TITLE
Complete cross-page navigation across all pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project loosely tracks dated entries (no strict semver).
 - Public `changelog.html` page, generated from this file at deploy time and
   linked from the site footer.
 
+### Changed
+
+- Completed cross-page navigation so every main page links to all of the
+  others. Added the missing **Home** and **Skills** links to the top nav and
+  footer of the Roles, Projects, and Certifications pages, and the missing
+  **Compass** and **Roles** links (plus a footer page-nav row) on the Skills
+  page.
+
 ## [2026-04-27]
 
 ### Added
@@ -63,4 +71,3 @@ and this project loosely tracks dated entries (no strict semver).
 
 - `pages-deploy.yml` permissions tightened to least-privilege per job
   (`contents: read`, `pages: write`, `id-token: write` only on the deploy job).
-</content>

--- a/certification_strategy.html
+++ b/certification_strategy.html
@@ -186,8 +186,10 @@ body{background:var(--gray-bg);color:var(--text);font-family:'Georgia',serif;min
 <nav class="nav">
   <span class="nav-brand">Security &amp; Cloud · Certification Strategy</span>
   <div class="nav-links">
+    <a class="nav-link back" href="index.html">Home</a>
     <a class="nav-link" href="ms_security_roles.html">Roles →</a>
     <a class="nav-link" href="ms_security_projects.html">Projects →</a>
+    <a class="nav-link" href="skills_inventory.html">Skills →</a>
     <a class="nav-link back" href="ms_security_compass.html">Security Compass</a>
   </div>
 </nav>
@@ -638,8 +640,10 @@ body{background:var(--gray-bg);color:var(--text);font-family:'Georgia',serif;min
 <div class="footer">
   <span>Certification Strategy &amp; Roadmap · v1 · Last updated: <!-- LAST_UPDATED -->unreleased<!-- /LAST_UPDATED --></span>
   <div style="display:flex;gap:1.5rem">
+    <a href="index.html">← Home</a>
     <a href="ms_security_roles.html">Roles →</a>
     <a href="ms_security_projects.html">Projects →</a>
+    <a href="skills_inventory.html">Skills →</a>
     <a href="ms_security_compass.html">← Security Compass</a>
   </div>
 </div>

--- a/ms_security_projects.html
+++ b/ms_security_projects.html
@@ -195,8 +195,10 @@ body{background:var(--gray-bg);color:var(--text);
 <nav class="nav">
   <span class="nav-brand">Microsoft Security · Consultant Reference</span>
   <div class="nav-links">
+    <a class="nav-link back" href="index.html">Home</a>
     <a class="nav-link" href="ms_security_roles.html">Roles →</a>
     <a class="nav-link" href="certification_strategy.html">Certifications →</a>
+    <a class="nav-link" href="skills_inventory.html">Skills →</a>
     <a class="nav-link back" href="ms_security_compass.html">Security Compass</a>
   </div>
 </nav>
@@ -536,8 +538,10 @@ body{background:var(--gray-bg);color:var(--text);
 <div class="footer">
   <span>Microsoft Security · Projects Inventory · Last updated: <!-- LAST_UPDATED -->unreleased<!-- /LAST_UPDATED --></span>
   <div style="display:flex;gap:1.5rem">
+    <a href="index.html">← Home</a>
     <a href="ms_security_roles.html">Roles →</a>
     <a href="certification_strategy.html">Certifications →</a>
+    <a href="skills_inventory.html">Skills →</a>
     <a href="ms_security_compass.html">← Security Compass</a>
   </div>
 </div>

--- a/ms_security_roles.html
+++ b/ms_security_roles.html
@@ -85,8 +85,10 @@ body{background:var(--gray-bg);color:var(--text);font-family:'Georgia',serif;min
 <nav class="nav">
   <span class="nav-brand">Microsoft Security · Consultant Reference</span>
   <div style="display:flex;gap:.5rem">
+    <a class="nav-link" href="index.html" style="font-size:12px;color:var(--text3);text-decoration:none;padding:5px 12px;border:1px solid var(--border);border-radius:20px;font-family:monospace">← Home</a>
     <a class="nav-link" href="ms_security_projects.html" style="font-size:12px;color:var(--text3);text-decoration:none;padding:5px 12px;border:1px solid var(--border);border-radius:20px;font-family:monospace">Projects →</a>
     <a class="nav-link" href="certification_strategy.html" style="font-size:12px;color:var(--text3);text-decoration:none;padding:5px 12px;border:1px solid var(--border);border-radius:20px;font-family:monospace">Certifications →</a>
+    <a class="nav-link" href="skills_inventory.html" style="font-size:12px;color:var(--text3);text-decoration:none;padding:5px 12px;border:1px solid var(--border);border-radius:20px;font-family:monospace">Skills →</a>
     <a class="nav-link" href="ms_security_compass.html">Security Compass</a>
   </div>
 </nav>
@@ -463,8 +465,10 @@ body{background:var(--gray-bg);color:var(--text);font-family:'Georgia',serif;min
 <div class="footer">
   <span>Microsoft Security · Roles &amp; Scenarios · v2 · Last updated: <!-- LAST_UPDATED -->unreleased<!-- /LAST_UPDATED --></span>
   <div style="display:flex;gap:1rem">
+    <a href="index.html" style="color:inherit;text-decoration:none;opacity:.6">← Home</a>
     <a href="ms_security_projects.html" style="color:inherit;text-decoration:none;opacity:.6">Projects →</a>
     <a href="certification_strategy.html" style="color:inherit;text-decoration:none;opacity:.6">Certifications →</a>
+    <a href="skills_inventory.html" style="color:inherit;text-decoration:none;opacity:.6">Skills →</a>
     <a href="ms_security_compass.html" style="color:inherit;text-decoration:none;opacity:.6">← Security Compass</a>
   </div>
 </div>

--- a/skills_inventory.html
+++ b/skills_inventory.html
@@ -109,9 +109,11 @@
 <nav class="nav">
   <span>Marcus Jacobson · Skills Inventory</span>
   <div class="nav-links">
+    <a class="back" href="index.html">← Home</a>
+    <a href="ms_security_compass.html">Compass →</a>
+    <a href="ms_security_roles.html">Roles →</a>
     <a href="ms_security_projects.html">Projects →</a>
     <a href="certification_strategy.html">Certifications →</a>
-    <a class="back" href="index.html">← Home</a>
   </div>
 </nav>
 
@@ -283,6 +285,7 @@
 
   <div class="footer">
     <span>Marcus Jacobson · Skills Inventory · v1</span>
+    <span><a href="index.html">Home</a> · <a href="ms_security_compass.html">Compass</a> · <a href="ms_security_roles.html">Roles</a> · <a href="ms_security_projects.html">Projects</a> · <a href="certification_strategy.html">Certifications</a></span>
     <span>Last updated: <!-- LAST_UPDATED -->unreleased<!-- /LAST_UPDATED --> · <a href="https://www.linkedin.com/in/marcus-jacobson-tech/">linkedin ↗</a> · <a href="https://github.com/marcusjacobson/portfolio">github ↗</a></span>
   </div>
 


### PR DESCRIPTION
## Summary

Standardizes cross-page navigation so every main page links to all of the other main pages, in both the top nav and the footer. Only the missing nav links were added — no restyling, no content rewrites. Each page keeps its own existing nav markup/style, and the `<!-- LAST_UPDATED -->` templating, doctype, and all page content are preserved byte-for-byte.

The six main pages are: Home (`index.html`), Compass (`ms_security_compass.html`), Roles (`ms_security_roles.html`), Projects (`ms_security_projects.html`), Certifications (`certification_strategy.html`), Skills (`skills_inventory.html`). Target per inner page: link to the other five, in the order Home · Compass · Roles · Projects · Certifications · Skills (excluding the current page).

## Per-page nav audit (gaps found → added)

| Page | Top nav before | Footer nav before | Added (top + footer) |
|---|---|---|---|
| `index.html` | Card grid links to Compass, Roles, Projects, Certifications, Skills (all 5) | n/a (footer is meta links only) | **No change** — grid already links to all five other pages |
| `ms_security_compass.html` | Home, Projects, Roles, Certifications, Skills (all 5) | "Built by" credit block (Home only — not a multi-link footer nav bar) | **No change** — top nav already complete |
| `ms_security_roles.html` | Projects, Certifications, Compass | Projects, Certifications, Compass | **Home, Skills** (top + footer) |
| `ms_security_projects.html` | Roles, Certifications, Compass | Roles, Certifications, Compass | **Home, Skills** (top + footer) |
| `certification_strategy.html` | Roles, Projects, Compass | Roles, Projects, Compass | **Home, Skills** (top + footer) |
| `skills_inventory.html` | Projects, Certifications, Home | none (meta links only) | Top: **Compass, Roles** (reordered to canonical Home · Compass · Roles · Projects · Certifications); Footer: **added a page-nav row** linking Home · Compass · Roles · Projects · Certifications |

After the change, each of the four inner pages (Roles, Projects, Certifications, Skills) links to all five other main pages in both its top nav and its footer.

## Files changed

- `ms_security_roles.html` — added Home + Skills nav links (top + footer)
- `ms_security_projects.html` — added Home + Skills nav links (top + footer)
- `certification_strategy.html` — added Home + Skills nav links (top + footer)
- `skills_inventory.html` — added Compass + Roles to top nav; added footer page-nav row
- `CHANGELOG.md` — `[Unreleased] → Changed` entry recording the navigation completion

## Verification

- Link check: every internal `*.html` href resolves to a file in the repo; no broken links.
- No page links to itself in its own nav (0 self-links on all four edited pages).
- Each edited page references all five other main pages exactly twice (top nav + footer); Skills additionally retains its six in-content "Compass ↗" deep-links.
- HTML remains well-formed; `<!-- LAST_UPDATED -->unreleased<!-- /LAST_UPDATED -->` templating intact on every page.
- `index.html`, `ms_security_compass.html`, and `changelog.html` are unchanged (already complete or out of scope).

No merge requested — leaving for maintainer review and the required CI checks (pages-build, lint, visual regression, link-check).