### PR TITLE
ci(dependabot): group github-actions updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       day: monday
     labels: [dependencies, github-actions]
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - '*'
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
## What

Adds a `groups:` entry to the `github-actions` ecosystem in `.github/dependabot.yml` (pattern `'*'`), mirroring the existing npm `dev-tooling` group.

## Why

Currently every GitHub Actions bump opens its own PR (e.g. #338, #339, #342 this cycle). Each merge then requires rebasing the others, which is avoidable churn. Grouping collapses the weekly action bumps into a single PR — one rebase, one CI run, one merge.

## Notes

- Pattern `'*'` groups all action updates (including majors) like the npm group does, for consistency. Majors still surface in the grouped PR body for review.
- Config-only change; no site/content impact, so no `CHANGELOG.md` entry.