### PR TITLE
ci(visual): add update_snapshots dispatch input to regenerate baselines

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -11,6 +11,11 @@ on:
       - 'package.json'
       - '.github/workflows/visual-regression.yml'
   workflow_dispatch:
+    inputs:
+      update_snapshots:
+        description: 'Regenerate visual baselines and upload them as the visual-baselines artifact'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -35,8 +40,21 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
+      - name: Update visual baselines
+        if: ${{ inputs.update_snapshots }}
+        run: npm run test:visual:update
+
+      - name: Upload regenerated baselines
+        if: ${{ inputs.update_snapshots }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: visual-baselines
+          path: tests/visual/__snapshots__/
+          retention-days: 14
+
       - name: Run visual tests
         id: visual
+        if: ${{ ! inputs.update_snapshots }}
         # Option B: advisory until Linux baselines are committed.
         # Generate baselines via:
         #   docker run --rm -v ${PWD}:/work -w /work mcr.microsoft.com/playwright:v1.48.0-jammy \


### PR DESCRIPTION
## Summary

First of three PRs converting the visual-regression check from advisory to a real gate.

Adds a `workflow_dispatch` input `update_snapshots` (boolean, default `false`) to `visual-regression.yml`:

- When dispatched with `update_snapshots=true`: skips the normal advisory test step, runs `npm run test:visual:update`, and uploads `tests/visual/__snapshots__/` as an artifact named `visual-baselines`.
- On normal `pull_request` runs (and dispatch with the default `false`): unchanged — the advisory `Run visual tests` step runs as before.

Permissions stay least-privilege (`contents: read`, `pull-requests: write`) — baselines are uploaded as an artifact, not committed, so no `contents: write` is needed.

## Why

CI runs on Linux, but the only committed baselines are `*-win32.png` from local runs, which is why the check is advisory. This input lets us regenerate Linux baselines in CI (PR 2) before flipping the check to a gate (PR 3).

## Tested

- [x] YAML structure reviewed; `if:` guards make the test step and the update steps mutually exclusive.
- [x] CI/workflow-only change — no site HTML touched, no CHANGELOG entry required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)