### PR TITLE
ci(visual): install webkit and always upload baselines on snapshot dispatch

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -38,14 +38,18 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        # desktop project uses chromium; mobile/tablet emulate iPhone/iPad (webkit).
+        run: npx playwright install --with-deps chromium webkit
 
       - name: Update visual baselines
         if: ${{ inputs.update_snapshots }}
         run: npm run test:visual:update
 
       - name: Upload regenerated baselines
-        if: ${{ inputs.update_snapshots }}
+        # Upload even if the update step exits non-zero: Playwright reports a
+        # non-zero status when it writes first-time baselines, but the PNGs are
+        # still produced and are what we want to capture.
+        if: ${{ always() && inputs.update_snapshots }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: visual-baselines


### PR DESCRIPTION
## Summary

Follow-up correction to #348 so the `update_snapshots` dispatch path can actually produce a complete set of Linux baselines.

Two fixes to `visual-regression.yml`:

1. **Install webkit as well as chromium.** The `desktop` Playwright project uses chromium, but the `mobile` and `tablet` projects emulate iPhone 13 / iPad (gen 7), which default to **webkit**. CI only installed chromium, so mobile/tablet runs errored with `Executable doesn't exist ... webkit`. The advisory `continue-on-error: true` was masking this on PR runs; it would make the gate permanently red once removed.
2. **Upload regenerated baselines even when the update step exits non-zero.** Playwright returns a non-zero status when it writes first-time baselines (`A snapshot doesn't exist ..., writing actual`), which previously skipped the upload. Guarding the upload with `always() && inputs.update_snapshots` captures the PNGs that were still produced.

## Why

A first dispatch (`update_snapshots=true`) on `main` failed: only the 5 chromium/desktop baselines were written (webkit missing), and the artifact upload was skipped because the update step exited 1. Without these fixes, baseline generation can't complete and the eventual gate (#3) would never pass.

## Tested

- [x] Will re-dispatch after merge and confirm the `visual-baselines` artifact contains all 15 `*-linux.png` (5 pages × 3 projects).
- [x] CI/workflow-only change — no site HTML touched, no CHANGELOG entry required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)