### PR TITLE
test(visual): stabilize fullPage screenshots via min-height stylePath

### DIFF
--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     toHaveScreenshot: {
       maxDiffPixelRatio: 0.01,
       animations: 'disabled',
+      stylePath: resolve(__dirname, 'visual/screenshot-stabilize.css'),
     },
   },
   projects: [

--- a/tests/visual/screenshot-stabilize.css
+++ b/tests/visual/screenshot-stabilize.css
@@ -1,0 +1,16 @@
+/*
+ * Injected before every visual screenshot via `expect.toHaveScreenshot.stylePath`
+ * in tests/playwright.config.ts. Site CSS is not affected.
+ *
+ * The pages set `body { min-height: 100vh }`. During a `fullPage` capture
+ * Playwright resizes the viewport to fit the document, which feeds back into
+ * `100vh` and changes the body height in turn. The trailing background padding
+ * then jitters a few pixels between consecutive captures, so Playwright reports
+ * "Failed to take two consecutive stable screenshots" even though the rendered
+ * content is pixel-identical. Pinning min-height to 0 breaks that feedback loop,
+ * making the captured height deterministic (equal to the content height).
+ */
+html,
+body {
+  min-height: 0 !important;
+}


### PR DESCRIPTION
## Summary

Prerequisite for making the visual-regression check a real gate.

Adds `tests/visual/screenshot-stabilize.css` and wires it through `expect.toHaveScreenshot.stylePath` in `tests/playwright.config.ts`. The stylesheet sets `html, body { min-height: 0 !important }` only for the duration of a screenshot; the site's own CSS is untouched.

## Why

A dispatched baseline-generation run showed `certification_strategy.html` (desktop) failing with **"Failed to take two consecutive stable screenshots"** — height flapping between 5300px and 5307px. Pixel analysis of the report artifact proved:

- The rendered content is **byte-identical** across the two captures (max per-pixel diff = 0 over all 5300 shared rows).
- The only difference is **7 extra rows of body-background padding at the very bottom** (`--gray-bg` = `#111110`).

Root cause: the pages set `body { min-height: 100vh }`. During a `fullPage` capture Playwright resizes the viewport to fit the document, which feeds back into `100vh`, so the trailing background height never settles. Neutralizing `min-height` during the screenshot breaks the loop and makes the captured height deterministic. Because it is applied via `stylePath`, both baseline generation and comparison use it, so they stay consistent.

This also slightly trims trailing whitespace from every page's baseline, which is why all baselines will be regenerated in the follow-up PR.

## Tested

- [x] Pixel-level diff of the failing run's artifact confirmed content identical; only trailing whitespace jitter.
- [x] Config-only/test change — no site HTML/CSS touched, no CHANGELOG entry required.
- [ ] Stability confirmed end-to-end in the follow-up baseline PR's advisory check (all 15 tests pass, no stabilization failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)