### PR TITLE
ci(visual): make visual regression a required gate (drop continue-on-error)

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -59,16 +59,14 @@ jobs:
       - name: Run visual tests
         id: visual
         if: ${{ ! inputs.update_snapshots }}
-        # Option B: advisory until Linux baselines are committed.
-        # Generate baselines via:
-        #   docker run --rm -v ${PWD}:/work -w /work mcr.microsoft.com/playwright:v1.48.0-jammy \
-        #     bash -c "npm ci && npx playwright test --update-snapshots"
-        # then commit tests/visual/__snapshots__/ and remove this continue-on-error.
-        continue-on-error: true
+        # Now a required gate: a visual diff fails the check. To refresh baselines
+        # after an intentional change, dispatch this workflow with
+        # update_snapshots=true and commit the visual-baselines artifact.
         run: npm run test:visual
 
       - name: Upload diff report
-        if: steps.visual.outcome == 'failure'
+        # always() so this still runs after the now-failing visual step.
+        if: ${{ always() && steps.visual.outcome == 'failure' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
@@ -76,7 +74,7 @@ jobs:
           retention-days: 14
 
       - name: Comment on PR with failure note
-        if: steps.visual.outcome == 'failure'
+        if: ${{ always() && steps.visual.outcome == 'failure' && github.event_name == 'pull_request' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |


### PR DESCRIPTION
## Summary

Final step: flips the visual-regression check from advisory to a real gate, now that stable Linux baselines are committed (#352).

- Removes `continue-on-error: true` from the **Run visual tests** step, so a visual diff fails the check.
- Updates the **Upload diff report** and **Comment on PR** steps to `always() && steps.visual.outcome == 'failure'`. Without `always()`, a failing visual step would auto-skip these (GitHub skips subsequent steps after a failure unless the `if` uses a status function), so the diff artifact and PR comment — the whole point on failure — would never run.
- Adds `github.event_name == 'pull_request'` to the comment step: its script reads `context.payload.pull_request.number`, which is null on a `workflow_dispatch` run, so it must only fire for PR events.
- Replaces the stale "Option B / advisory" comment with a note on how to refresh baselines (dispatch with `update_snapshots=true`, commit the artifact).

## Why

CI runs on Linux and now has committed, reproducible `*-linux.png` baselines (#352) plus screenshot stabilization (#351). The advisory escape hatch is no longer needed and was masking real diffs.

## Verification chain

- #352's advisory run already proved `npm run test:visual` is **15 passed, 0 failed, no stabilization errors** against the committed baselines.
- This PR's own `playwright` check is now the gate running for real on an unchanged tree — it must be green.

## Tested

- [x] `if` conditions reviewed: on `update_snapshots=true`, the visual step is skipped (`outcome == 'skipped'`) so the report/comment steps don't fire; on a PR diff failure they do.
- [x] CI/workflow-only change — no site HTML touched, no CHANGELOG entry required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)