### PR TITLE
ci: auto-merge grouped Dependabot patch/minor bumps once checks pass

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,34 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  automerge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    permissions:
+      # Dependabot-triggered runs get a read-only token by default; restore the
+      # write scopes needed to enable auto-merge, scoped to this job only.
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: Enable auto-merge for patch + minor
+        # Majors stay manual (e.g. gitleaks v2->v3) so they keep a human review.
+        # Auto-merge still obeys branch protection: GitHub only completes the
+        # merge once the required checks pass.
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependabot-automerge.yml` so grouped **patch** and **minor** Dependabot bumps merge themselves once required checks pass. **Majors stay manual** (e.g. the gitleaks v2→v3 jump keeps a human review).

- Triggers on `pull_request`, gated to `github.actor == 'dependabot[bot]'`.
- `dependabot/fetch-metadata` reads `update-type`; only `semver-patch` / `semver-minor` enable auto-merge via `gh pr merge --auto --squash`.
- Top-level `permissions: contents: read`; the `automerge` job alone elevates to `contents: write` + `pull-requests: write` (Dependabot-triggered runs get a read-only token by default).

## Verification against current GitHub docs (this area changed recently)

- **fetch-metadata pin**: latest is now **v3.1.0** — pinned to its commit SHA `25dd0e34f4fe68f24cc83900b1fe3fe149efef98` with a `# v3.1.0` comment (repo SHA-pin convention; passes the maturity-scan audit). v3.0.0's only breaking change is requiring the Node 24 Actions runtime (supported on `ubuntu-latest`); the `update-type` output and usage are unchanged from v2. The original `# v2.x` note is now stale.
- **Permissions for Dependabot runs**: confirmed against GitHub's "Automating Dependabot with GitHub Actions" — its auto-merge example uses the same shape (`on: pull_request`, `dependabot[bot]` guard, job-level `contents: write` + `pull-requests: write`, `gh pr merge --auto`). The job-level block restores the write scopes for Dependabot-triggered runs.

## Prereqs handled

- **Allow auto-merge**: was disabled; enabled it on the repo (squash merge already allowed).
- **Required approvals**: branch protection on `main` requires **0** approvals, so auto-merge completes on green checks with no approval step needed.

## Why it's safe

Auto-merge obeys branch protection — GitHub only completes the merge after the required status checks pass. Majors are excluded so notable upgrades keep a human in the loop. `contents: write` is scoped to this one job; the rest of the workflow stays `contents: read`.

> Note for the maintainer: the required status check contexts on `main` are `lint`, `lychee`, `scan`, `analyze (javascript-typescript)`. `build` and `playwright` are **not** required contexts because they're path-filtered (per the repo's documented "path-filtered jobs cannot be required" gotcha), so auto-merge does not block on them. Pre-existing config — flagging in case you want those gating Dependabot merges too.

## Tested

- [x] SHA pin is 40-char hex (passes maturity-scan SHA-pin audit).
- [x] This PR is not authored by Dependabot, so the `automerge` job is skipped here — it will only act on real Dependabot PRs.
- [x] CI/workflow-only change — no site HTML touched, no CHANGELOG entry required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)