### PR TITLE
ci(visual): always-report so playwright can be a required context

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,15 +1,13 @@
 name: Visual Regression
 
+# Runs on every PR so the `playwright` check is always reported and can be a
+# required, merge-blocking context. PRs that touch no visual-relevant files
+# fast-exit (the expensive steps skip) and the job still reports SUCCESS, so
+# requiring this context never deadlocks docs-only / config-only PRs.
+
 on:
   pull_request:
     branches: [main]
-    paths:
-      - '**/*.html'
-      - '**/*.css'
-      - '**/*.js'
-      - 'tests/**'
-      - 'package.json'
-      - '.github/workflows/visual-regression.yml'
   workflow_dispatch:
     inputs:
       update_snapshots:
@@ -27,17 +25,53 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history so the change-detection step can diff against the PR base.
+          fetch-depth: 0
+
+      - name: Detect visual-relevant changes
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # Non-PR events (workflow_dispatch) always run the full suite.
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "Non-PR event: treating as relevant."
+            exit 0
+          fi
+          # Match the path globs this workflow used to filter on.
+          files=$(git diff --name-only "$BASE_SHA"...HEAD)
+          echo "Changed files vs base:"
+          printf '%s\n' "$files"
+          relevant=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.html|*.css|*.js|tests/*|package.json|.github/workflows/visual-regression.yml)
+                relevant=true
+                break
+                ;;
+            esac
+          done <<< "$files"
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+          echo "Visual-relevant changes: $relevant"
 
       - name: Setup Node
+        if: ${{ steps.changes.outputs.relevant == 'true' || inputs.update_snapshots }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
+        if: ${{ steps.changes.outputs.relevant == 'true' || inputs.update_snapshots }}
         run: npm ci
 
       - name: Install Playwright browsers
+        if: ${{ steps.changes.outputs.relevant == 'true' || inputs.update_snapshots }}
         # desktop project uses chromium; mobile/tablet emulate iPhone/iPad (webkit).
         run: npx playwright install --with-deps chromium webkit
 
@@ -58,10 +92,10 @@ jobs:
 
       - name: Run visual tests
         id: visual
-        if: ${{ ! inputs.update_snapshots }}
-        # Now a required gate: a visual diff fails the check. To refresh baselines
-        # after an intentional change, dispatch this workflow with
-        # update_snapshots=true and commit the visual-baselines artifact.
+        if: ${{ steps.changes.outputs.relevant == 'true' && ! inputs.update_snapshots }}
+        # Required gate: a visual diff fails the check. To refresh baselines after
+        # an intentional change, dispatch this workflow with update_snapshots=true
+        # and commit the visual-baselines artifact.
         run: npm run test:visual
 
       - name: Upload diff report


### PR DESCRIPTION
## Summary

Refactors `visual-regression.yml` so the `playwright` check reports on **every** PR — a prerequisite for making it a required, merge-blocking context without deadlocking PRs that touch no visual-relevant files.

- **Dropped the `paths:` filter** from the `pull_request` trigger (kept `branches: [main]` and the `workflow_dispatch` `update_snapshots` path). The job now runs on every PR.
- **`fetch-depth: 0`** on checkout so the new step can diff against the PR base.
- **New "Detect visual-relevant changes" step** — `git diff --name-only <base.sha>...HEAD`, matched against the old globs (`**/*.html`, `**/*.css`, `**/*.js`, `tests/**`, `package.json`, `.github/workflows/visual-regression.yml`) in a shell `case`, emitting `relevant=true/false`. No new action dependency. Non-PR (dispatch) events are treated as relevant so the manual/update paths keep working.
- **Expensive steps gated** on `relevant == 'true' || inputs.update_snapshots` (Setup Node, `npm ci`, Playwright install) and `relevant == 'true' && ! inputs.update_snapshots` (Run visual tests). On an irrelevant PR those skip and the job still finishes **SUCCESS**, so the `playwright` context is a green-skip in seconds — no browsers launched.
- Job stays named `playwright` (stable context name). Dispatch `update_snapshots` path and the `always()` diff-report / PR-comment steps are unchanged. Permissions unchanged (`contents: read` top-level, `pull-requests: write` for the comment).

## Behavior matrix

| PR / event | `relevant` | Visual test runs? | `playwright` result |
|---|---|---|---|
| Touches `*.html` / `*.css` / `*.js` / `tests/**` / `package.json` / this workflow | true | yes | real pass/fail |
| Docs-only (`*.md`), other workflows, configs | false | no (steps skip) | green-skip, seconds |
| `workflow_dispatch` `update_snapshots=true` | n/a | no (update path) | regenerates baselines |

This PR edits `visual-regression.yml`, which is in the relevant set, so its own `playwright` check exercises the **real** test path.

## Next steps (separate, after this is on main)

- Add `playwright` to branch-protection required contexts.
- Align the "required contexts" lines in AGENTS.md.

## Tested

- [x] CI/workflow-only change — no site HTML touched, no CHANGELOG entry required.
- [x] Will confirm a docs-only throwaway PR green-skips before requiring the context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)