### PR TITLE
test: throwaway docs-only PR (verify visual gate green-skips)

### DIFF
--- a/_deadlock-check.md
+++ b/_deadlock-check.md
@@ -1,0 +1,3 @@
+# Deadlock check (throwaway)
+
+Temporary PR to confirm the visual-regression check green-skips on docs-only PRs. Not for merge.


### PR DESCRIPTION
Throwaway PR to confirm the `playwright` check reports SUCCESS in seconds on a docs-only change (no browsers launched). **Do not merge** — will be closed after verification.