### PR TITLE
content: repoint Purview Data Discovery Methods card to Lab Navigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project loosely tracks dated entries (no strict semver).
 
 ### Changed
 
+- Repointed the **Purview Data Discovery Methods** project card from the GitHub repo
+  to its published Lab Navigator landing page
+  (`marcusjacobson.github.io/Purview-Data-Discovery-Methods`).
 - Reordered the Microsoft Purview project cards to lead with the active *Purview as
   Code* project ahead of *Purview Data Discovery Methods*, and shortened both card
   titles ("Purview-as-Code — Generic Template" → "Purview as Code"; "Purview Discovery

--- a/ms_security_projects.html
+++ b/ms_security_projects.html
@@ -362,7 +362,7 @@ a.ddnav-bar-brand:hover{color:rgba(232,230,224,0.8)}
         <span class="field-label">Status</span>
         <span class="status complete">Complete</span>
       </div>
-      <a class="github-link" href="https://github.com/marcusjacobson/Purview-Data-Discovery-Methods" target="_blank" rel="noopener">marcusjacobson/Purview-Data-Discovery-Methods</a>
+      <a class="github-link" href="https://marcusjacobson.github.io/Purview-Data-Discovery-Methods/" target="_blank" rel="noopener">Purview Data Discovery Methods · Lab Navigator</a>
     </div>
 
   </div>


### PR DESCRIPTION
## Summary

Repoints the **Purview Data Discovery Methods** project card (Microsoft Purview section of `ms_security_projects.html`) from the raw GitHub repo to its newly published **Lab Navigator** landing page on GitHub Pages:

- **Before:** `https://github.com/marcusjacobson/Purview-Data-Discovery-Methods` → *marcusjacobson/Purview-Data-Discovery-Methods*
- **After:** `https://marcusjacobson.github.io/Purview-Data-Discovery-Methods/` → *Purview Data Discovery Methods · Lab Navigator*

The Lab Navigator (`index.html` / `lab-navigator.html`) was published to the public [`Purview-Data-Discovery-Methods`](https://github.com/marcusjacobson/Purview-Data-Discovery-Methods) repo and GitHub Pages was enabled from the default branch root. The live page returns **200** and serves the navigator, so `lychee` will resolve the new URL.

## Changes

- `ms_security_projects.html` — updated the card's `github-link` href + visible text (the `↗` prefix is CSS-supplied).
- `CHANGELOG.md` — new entry under `[Unreleased] → Changed`.

## Visual baseline

This relabels the card's visible text, so it is a visual change. Per the last three Purview content PRs, only the **projects page mobile-linux** baseline diffs; refreshed via the `update_snapshots` dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)