### PR TITLE
content: repoint Purview as Code card to published overview page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project loosely tracks dated entries (no strict semver).
 
 ### Changed
 
+- Repointed the **Purview as Code** project card from the GitHub repo to its
+  published project overview page (`marcusjacobson.github.io/Purview-as-Code-Generic`).
 - Repointed the **Purview Data Discovery Methods** project card from the GitHub repo
   to its published Lab Navigator landing page
   (`marcusjacobson.github.io/Purview-Data-Discovery-Methods`).

--- a/ms_security_projects.html
+++ b/ms_security_projects.html
@@ -334,7 +334,7 @@ a.ddnav-bar-brand:hover{color:rgba(232,230,224,0.8)}
         <span class="field-label">Status</span>
         <span class="status active">Active</span>
       </div>
-      <a class="github-link" href="https://github.com/marcusjacobson/Purview-as-Code-Generic" target="_blank" rel="noopener">marcusjacobson/Purview-as-Code-Generic</a>
+      <a class="github-link" href="https://marcusjacobson.github.io/Purview-as-Code-Generic/" target="_blank" rel="noopener">Purview as Code · Overview</a>
     </div>
 
     <div class="card purple">


### PR DESCRIPTION
## Summary

Repoints the **Purview as Code** project card on the Microsoft Security projects page from the GitHub repository to its published GitHub Pages overview, so visitors land on the curated project overview rather than the raw repo. Matches the recent repointing of the *Purview Data Discovery Methods* card.

## Changes

- `ms_security_projects.html`: Purview as Code card `github-link` now points to `https://marcusjacobson.github.io/Purview-as-Code-Generic/` with text **Purview as Code · Overview** (was the repo URL / `marcusjacobson/Purview-as-Code-Generic`).
- `CHANGELOG.md`: new bullet at the top of `[Unreleased] → Changed`.

## Tested
- [ ] `npm run lint` passes locally
- [ ] `npm run test:visual` passes locally (or baselines updated)
- [x] Manually verified the affected page
- [x] Updated `CHANGELOG.md` for user-visible changes

## Security review
- [x] No new external scripts without SRI
- [x] No secrets / PII in diff
- [x] No workflow changes

## Related

> ⚠️ **Do not merge until GitHub Pages is live on `Purview-as-Code-Generic`.** The target `https://marcusjacobson.github.io/Purview-as-Code-Generic/` currently returns **404**, so the `lychee` link check will fail until Pages is published (this URL is intentionally not excluded in `tests/lychee.toml`).
