### PR TITLE
content: repoint Purview as Code card after repo rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ and this project loosely tracks dated entries (no strict semver).
 
 ### Changed
 
-- Repointed the **Purview as Code** project card from the GitHub repo to its
-  published project overview page (`marcusjacobson.github.io/Purview-as-Code-Generic`).
+- Repointed the **Purview as Code** project card to its published project overview
+  page (`marcusjacobson.github.io/Purview-as-Code`), following the repository rename
+  from Purview-as-Code-Generic.
 - Repointed the **Purview Data Discovery Methods** project card from the GitHub repo
   to its published Lab Navigator landing page
   (`marcusjacobson.github.io/Purview-Data-Discovery-Methods`).

--- a/ms_security_projects.html
+++ b/ms_security_projects.html
@@ -334,7 +334,7 @@ a.ddnav-bar-brand:hover{color:rgba(232,230,224,0.8)}
         <span class="field-label">Status</span>
         <span class="status active">Active</span>
       </div>
-      <a class="github-link" href="https://marcusjacobson.github.io/Purview-as-Code-Generic/" target="_blank" rel="noopener">Purview as Code · Overview</a>
+      <a class="github-link" href="https://marcusjacobson.github.io/Purview-as-Code/" target="_blank" rel="noopener">Purview as Code · Overview</a>
     </div>
 
     <div class="card purple">


### PR DESCRIPTION
## Summary

Repoints the **Purview as Code** project card on the Microsoft Security projects page to `https://marcusjacobson.github.io/Purview-as-Code/`, following the rename of the `Purview-as-Code-Generic` repository to `Purview-as-Code`. Link text is unchanged. The new Pages URL is already live (verified `200`), so `lychee` passes without any config change.

## Changes

- `ms_security_projects.html`: Purview as Code card `github-link` href → `https://marcusjacobson.github.io/Purview-as-Code/` (text **Purview as Code · Overview** unchanged).
- `CHANGELOG.md`: updated the existing `[Unreleased] → Changed` bullet to reference the new URL and note the repository rename.

## Tested
- [x] `lint` / `lychee` / `scan` / `analyze` / `playwright` / `build` green in CI
- [x] Link text unchanged, so no visual baseline refresh needed
- [x] Updated `CHANGELOG.md` for the user-visible change

## Security review
- [x] No new external scripts without SRI
- [x] No secrets / PII in diff
- [x] No workflow changes
